### PR TITLE
Add map state to MapContext

### DIFF
--- a/client/app/(tabs)/_layout.tsx
+++ b/client/app/(tabs)/_layout.tsx
@@ -7,6 +7,7 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { MapProvider } from '@/modules/map/MapContext';
 
 const TabBarMapIcon = ({ color }: { color: string }) => {
   return <IconSymbol size={28} name="map.fill" color={color} />;
@@ -17,34 +18,36 @@ const TabBarCalendarIcon = ({ color }: { color: string }) => {
 };
 
 const TabLayout = ({ colorScheme }: { colorScheme: 'light' | 'dark' }) => (
-  <Tabs
-    screenOptions={{
-      tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-      headerShown: false,
-      tabBarButton: HapticTab,
-      tabBarBackground: TabBarBackground,
-      tabBarStyle: Platform.select({
-        ios: {
-          position: 'absolute',
-        },
-        default: {},
-      }),
-    }}>
-    <Tabs.Screen
-      name="index"
-      options={{
-        title: 'Map',
-        tabBarIcon: TabBarMapIcon,
-      }}
-    />
-    <Tabs.Screen
-      name="calendar"
-      options={{
-        title: 'Calendar',
-        tabBarIcon: TabBarCalendarIcon,
-      }}
-    />
-  </Tabs>
+  <MapProvider>
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        headerShown: false,
+        tabBarButton: HapticTab,
+        tabBarBackground: TabBarBackground,
+        tabBarStyle: Platform.select({
+          ios: {
+            position: 'absolute',
+          },
+          default: {},
+        }),
+      }}>
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Map',
+          tabBarIcon: TabBarMapIcon,
+        }}
+      />
+      <Tabs.Screen
+        name="calendar"
+        options={{
+          title: 'Calendar',
+          tabBarIcon: TabBarCalendarIcon,
+        }}
+      />
+    </Tabs>
+  </MapProvider>
 );
 
 export default function App() {

--- a/client/app/(tabs)/index.tsx
+++ b/client/app/(tabs)/index.tsx
@@ -3,18 +3,20 @@ import React from 'react';
 
 import { SearchBar } from '@/components/SearchBar';
 import MapView from '@/modules/map/MapView';
-import { MapProvider } from '@/modules/map/MapContext';
+import { useMap, MapState } from '@/modules/map/MapContext';
 
 export default function HomeScreen() {
+  const { state } = useMap();
   return (
-    <MapProvider>
-      <View style={styles.container}>
-        <MapView />
+    <View style={styles.container}>
+      <MapView />
+      {state === MapState.Idle && (
         <View style={styles.searchContainer}>
           <SearchBar onSearch={(query) => console.log(query)} />
         </View>
-      </View>
-    </MapProvider>
+      )}
+      {state === MapState.RoutePlanning && <View></View>}
+    </View>
   );
 }
 

--- a/client/modules/map/MapContext.tsx
+++ b/client/modules/map/MapContext.tsx
@@ -4,13 +4,20 @@ import Mapbox from '@rnmapbox/maps';
 // downtown concordia campus (sgw)
 const DEFAULT_COORDINATES: [number, number] = [-73.5789, 45.4973];
 
+export enum MapState {
+  Idle,
+  RoutePlanning,
+}
+
 type MapContextType = {
   mapRef: React.RefObject<Mapbox.MapView>;
   cameraRef: React.RefObject<Mapbox.Camera>;
   centerCoordinate: [number, number];
   zoomLevel: number;
+  state: MapState;
   setCenterCoordinate: (centerCoordinate: [number, number]) => void;
   setZoomLevel: (zoomLevel: number) => void;
+  setState: (state: MapState) => void;
   flyTo: (coords: [number, number], zoomLevel?: number) => void;
 };
 
@@ -21,6 +28,7 @@ export const MapProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const cameraRef = useRef<Mapbox.Camera | null>(null);
   const [centerCoordinate, setCenterCoordinate] = useState<[number, number]>(DEFAULT_COORDINATES);
   const [zoomLevel, setZoomLevel] = useState(15);
+  const [state, setState] = useState<MapState>(MapState.Idle);
 
   const flyTo = useMemo(
     () => (newCenterCoordinate: [number, number], newZoomLevel?: number) => {
@@ -43,8 +51,10 @@ export const MapProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       cameraRef,
       centerCoordinate,
       zoomLevel,
+      state,
       setCenterCoordinate,
       setZoomLevel,
+      setState,
       flyTo,
     }),
     [centerCoordinate, zoomLevel, flyTo]

--- a/client/modules/map/MapContext.tsx
+++ b/client/modules/map/MapContext.tsx
@@ -57,7 +57,7 @@ export const MapProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       setState,
       flyTo,
     }),
-    [centerCoordinate, zoomLevel, flyTo]
+    [centerCoordinate, zoomLevel, state, flyTo]
   );
 
   return <MapContext.Provider value={value}>{children}</MapContext.Provider>;


### PR DESCRIPTION
Currently, there is no clear direction on how to handle our application's state (different modes, such as idle, route planning, route navigation, etc.), and so with this PR I introduce high-level state management that we can all leverage for our upcoming tasks.

A technical summary follows:
I introduced a state variable into the `MapContext`, and I moved the call to `MapProvider` from `index.tsx` to `(tabs)/_layout.tsx`, so that `index.tsx` can access the state itself (and so that our calendar tab that we'll implement later will also have access to this state).

Please take a look at the changes to `index.tsx` to see how to leverage the `state` variable (obtained from the `useMap` hook) to decide what components to render over the `MapView`.

This PR does _not_ resolve user story 2.2.