### PR TITLE
Render route directions

### DIFF
--- a/client/components/RoutePlanner.tsx
+++ b/client/components/RoutePlanner.tsx
@@ -4,13 +4,21 @@ import { Ionicons } from '@expo/vector-icons';
 import { MapState, useMap } from '@/modules/map/MapContext';
 
 export function RoutePlanner() {
-  const { setState } = useMap();
-  const [startLocationString, setStartLocationString] = React.useState<string>('');
-  const [endLocationString, setEndLocationString] = React.useState<string>('');
-  const swapLocations = () => {
-    setStartLocationString(endLocationString);
-    setEndLocationString(startLocationString);
+  const { setState, loadRoute } = useMap();
+  const [startLocationQuery, setStartLocationQuery] = React.useState<string>('');
+  const [endLocationQuery, setEndLocationQuery] = React.useState<string>('');
+
+  const handleBlur = async () => {
+    if (startLocationQuery && endLocationQuery) {
+      await loadRoute(startLocationQuery, endLocationQuery);
+    }
   };
+
+  const swapLocations = () => {
+    setStartLocationQuery(endLocationQuery);
+    setEndLocationQuery(startLocationQuery);
+  };
+
   return (
     <View style={styles.locationRangeForm}>
       <View style={styles.locationRangeFormRow}>
@@ -20,8 +28,9 @@ export function RoutePlanner() {
             style={styles.input}
             placeholder="Start location"
             placeholderTextColor="#666"
-            value={startLocationString}
-            onChangeText={(query) => setStartLocationString(query)}
+            value={startLocationQuery}
+            onChangeText={(query) => setStartLocationQuery(query)}
+            onBlur={handleBlur}
           />
         </View>
         <Pressable onPress={() => setState(MapState.Idle)}>
@@ -35,8 +44,9 @@ export function RoutePlanner() {
             style={styles.input}
             placeholder="End location"
             placeholderTextColor="#666"
-            value={endLocationString}
-            onChangeText={(query) => setEndLocationString(query)}
+            value={endLocationQuery}
+            onChangeText={(query) => setEndLocationQuery(query)}
+            onBlur={handleBlur}
           />
         </View>
         <Pressable onPress={swapLocations}>

--- a/client/modules/map/MapContext.tsx
+++ b/client/modules/map/MapContext.tsx
@@ -1,13 +1,20 @@
 import React, { createContext, useContext, useRef, useState, useMemo } from 'react';
 import Mapbox from '@rnmapbox/maps';
+import { getLocationCoordinates, getRoute } from './MapService';
 
-// downtown concordia campus (sgw)
-const DEFAULT_COORDINATES: [number, number] = [-73.5789, 45.4973];
+export type Coordinates = [number, number];
+export interface Location {
+  name: string | null;
+  coordinates: Coordinates;
+}
 
 export enum MapState {
   Idle,
   RoutePlanning,
 }
+
+// downtown concordia campus (sgw)
+const DEFAULT_COORDINATES: Coordinates = [-73.5789, 45.4973];
 
 type MapContextType = {
   mapRef: React.RefObject<Mapbox.MapView>;
@@ -15,10 +22,14 @@ type MapContextType = {
   centerCoordinate: [number, number];
   zoomLevel: number;
   state: MapState;
+  startLocation: Location | null;
+  endLocation: Location | null;
+  routeCoordinates: Coordinates[];
   setCenterCoordinate: (centerCoordinate: [number, number]) => void;
   setZoomLevel: (zoomLevel: number) => void;
   setState: (state: MapState) => void;
   flyTo: (coords: [number, number], zoomLevel?: number) => void;
+  loadRoute: (startLocationQuery: string, endLocationQuery: string) => Promise<void>;
 };
 
 const MapContext = createContext<MapContextType | undefined>(undefined);
@@ -28,7 +39,11 @@ export const MapProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const cameraRef = useRef<Mapbox.Camera | null>(null);
   const [centerCoordinate, setCenterCoordinate] = useState<[number, number]>(DEFAULT_COORDINATES);
   const [zoomLevel, setZoomLevel] = useState(15);
-  const [state, setState] = useState<MapState>(MapState.Idle);
+  const [state, setState] = useState<MapState>(MapState.RoutePlanning);
+
+  const [startLocation, setStartLocation] = useState<Location | null>(null);
+  const [endLocation, setEndLocation] = useState<Location | null>(null);
+  const [routeCoordinates, setRouteCoordinates] = useState<Coordinates[]>([]);
 
   const flyTo = useMemo(
     () => (newCenterCoordinate: [number, number], newZoomLevel?: number) => {
@@ -45,6 +60,28 @@ export const MapProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     [zoomLevel]
   );
 
+  const loadRoute = async (startLocationQuery: string, endLocationQuery: string): Promise<void> => {
+    return Promise.all([
+      getLocationCoordinates(startLocationQuery),
+      getLocationCoordinates(endLocationQuery),
+    ])
+      .then(([newStartLocation, newEndLocation]) => {
+        if (newStartLocation && newEndLocation) {
+          setStartLocation(newStartLocation);
+          setEndLocation(newEndLocation);
+          return getRoute(newStartLocation.coordinates, newEndLocation.coordinates);
+        }
+      })
+      .then((newRouteCoordinates) => {
+        if (newRouteCoordinates) {
+          setRouteCoordinates(newRouteCoordinates);
+        }
+      })
+      .catch((error) => {
+        console.error('Error setting route:', error);
+      });
+  };
+
   const value = useMemo(
     () => ({
       mapRef,
@@ -52,12 +89,16 @@ export const MapProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       centerCoordinate,
       zoomLevel,
       state,
+      startLocation,
+      endLocation,
+      routeCoordinates,
       setCenterCoordinate,
       setZoomLevel,
       setState,
       flyTo,
+      loadRoute,
     }),
-    [centerCoordinate, zoomLevel, state, flyTo]
+    [centerCoordinate, zoomLevel, state, startLocation, endLocation, routeCoordinates, flyTo]
   );
 
   return <MapContext.Provider value={value}>{children}</MapContext.Provider>;

--- a/client/modules/map/MapContext.tsx
+++ b/client/modules/map/MapContext.tsx
@@ -39,7 +39,7 @@ export const MapProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const cameraRef = useRef<Mapbox.Camera | null>(null);
   const [centerCoordinate, setCenterCoordinate] = useState<[number, number]>(DEFAULT_COORDINATES);
   const [zoomLevel, setZoomLevel] = useState(15);
-  const [state, setState] = useState<MapState>(MapState.RoutePlanning);
+  const [state, setState] = useState<MapState>(MapState.Idle);
 
   const [startLocation, setStartLocation] = useState<Location | null>(null);
   const [endLocation, setEndLocation] = useState<Location | null>(null);

--- a/client/modules/map/MapService.tsx
+++ b/client/modules/map/MapService.tsx
@@ -8,7 +8,7 @@ const getLocationCoordinates = async (locationQuery: string): Promise<Location |
     )}&access_token=${ACCESS_TOKEN}`
   );
   const data = await response.json();
-  if (data.features && data.features[0]) {
+  if (data?.features[0]) {
     const feature = data.features[0];
     return {
       name: locationQuery,
@@ -26,7 +26,7 @@ const getRoute = async (
     `https://api.mapbox.com/directions/v5/mapbox/driving/${startCoordinates[0]},${startCoordinates[1]};${endCoordinates[0]},${endCoordinates[1]}?geometries=geojson&access_token=${ACCESS_TOKEN}`
   );
   const data = await response.json();
-  if (data.routes && data.routes[0]) {
+  if (data?.routes[0]) {
     return data.routes[0].geometry.coordinates as Coordinates[];
   }
   return null;

--- a/client/modules/map/MapService.tsx
+++ b/client/modules/map/MapService.tsx
@@ -1,0 +1,35 @@
+import { Coordinates, Location } from './MapContext';
+const ACCESS_TOKEN = process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
+
+const getLocationCoordinates = async (locationQuery: string): Promise<Location | null> => {
+  const response = await fetch(
+    `https://api.mapbox.com/search/geocode/v6/forward?q=${encodeURIComponent(
+      locationQuery
+    )}&access_token=${ACCESS_TOKEN}`
+  );
+  const data = await response.json();
+  if (data.features && data.features[0]) {
+    const feature = data.features[0];
+    return {
+      name: locationQuery,
+      coordinates: feature.geometry.coordinates as Coordinates,
+    };
+  }
+  return null;
+};
+
+const getRoute = async (
+  startCoordinates: Coordinates,
+  endCoordinates: Coordinates
+): Promise<Coordinates[] | null> => {
+  const response = await fetch(
+    `https://api.mapbox.com/directions/v5/mapbox/driving/${startCoordinates[0]},${startCoordinates[1]};${endCoordinates[0]},${endCoordinates[1]}?geometries=geojson&access_token=${ACCESS_TOKEN}`
+  );
+  const data = await response.json();
+  if (data.routes && data.routes[0]) {
+    return data.routes[0].geometry.coordinates as Coordinates[];
+  }
+  return null;
+};
+
+export { getLocationCoordinates, getRoute };

--- a/client/modules/map/MapView.tsx
+++ b/client/modules/map/MapView.tsx
@@ -1,12 +1,22 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Mapbox from '@rnmapbox/maps';
 import React from 'react';
-import { useMap } from './MapContext';
+import { useMap, MapState } from './MapContext';
 
 Mapbox.setAccessToken(process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN as string);
 
 export default function MapView() {
-  const { mapRef, cameraRef, centerCoordinate, zoomLevel } = useMap();
+  const {
+    mapRef,
+    cameraRef,
+    centerCoordinate,
+    zoomLevel,
+    state,
+    startLocation,
+    endLocation,
+    routeCoordinates,
+  } = useMap();
+
   return (
     <Mapbox.MapView ref={mapRef} style={styles.map} styleURL={Mapbox.StyleURL.Street}>
       <Mapbox.Camera
@@ -16,6 +26,39 @@ export default function MapView() {
         animationMode="flyTo"
         animationDuration={2000}
       />
+
+      {state === MapState.RoutePlanning && startLocation !== null && endLocation !== null && (
+        <>
+          <Mapbox.MarkerView id="start" coordinate={startLocation.coordinates}>
+            <View style={[styles.marker, styles.startMarker]} />
+          </Mapbox.MarkerView>
+          <Mapbox.MarkerView id="end" coordinate={endLocation.coordinates}>
+            <View style={[styles.marker, styles.endMarker]} />
+          </Mapbox.MarkerView>
+          {routeCoordinates.length > 0 && (
+            <Mapbox.ShapeSource
+              id="routeSource"
+              shape={{
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                  type: 'LineString',
+                  coordinates: routeCoordinates,
+                },
+              }}>
+              <Mapbox.LineLayer
+                id="routeFill"
+                style={{
+                  lineColor: '#007AFF',
+                  lineWidth: 4,
+                  lineCap: 'round',
+                  lineJoin: 'round',
+                }}
+              />
+            </Mapbox.ShapeSource>
+          )}
+        </>
+      )}
     </Mapbox.MapView>
   );
 }
@@ -25,5 +68,18 @@ const styles = StyleSheet.create({
     flex: 1,
     width: '100%',
     height: '100%',
+  },
+  marker: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: 'white',
+  },
+  startMarker: {
+    backgroundColor: '#00B800',
+  },
+  endMarker: {
+    backgroundColor: '#FF0000',
   },
 });


### PR DESCRIPTION
Test this PR by:
1. Checking out this branch locally.
2. Manually changing the default state of the app to `RoutePlanning` in `client/modules/map/MapContext.tsx`.
3. Running the simulator.
4. Typing the name / identifier of a start and destination location in the input fields at the top of the screen.
5. Navigate the map view to verify that the directions are rendered on screen.