### PR TITLE
Fix bug for location dropdown (route planning)

### DIFF
--- a/client/components/LocationInput.tsx
+++ b/client/components/LocationInput.tsx
@@ -33,6 +33,7 @@ export default function LocationInput({
         placeholder={placeholder}
         placeholderTextColor="#666"
         value={query}
+        autoCorrect={false}
         onChangeText={(query) => setQuery(query)}
       />
       {query !== location?.name && (
@@ -40,7 +41,9 @@ export default function LocationInput({
           query={query}
           callback={(location) => {
             setLocation(location);
-            inputRef.current?.blur();
+            setTimeout(() => {
+              inputRef.current?.blur();
+            }, 0);
           }}
         />
       )}


### PR DESCRIPTION
Removed autocorrect and fixed the bug for route planning's location search by adding the setTimeout in LocationsAutocomplete (LocationInput.tsx file). 

A similar solution was implemented for the search bar in idle state in a previous PR. 

Before approving this PR, ensure my solution works by recreating the following steps:
1. Tap on search bar at the top of route planning state
2. Start typing a location
3. Tap one of the auto-complete locations
4. Ensure that the drop down of locations does not show up, and that everything works smoothly