### PR TITLE
Remove dependency on Google's distance matrix API

### DIFF
--- a/client/Types/Coordinate.tsx
+++ b/client/Types/Coordinate.tsx
@@ -1,1 +1,0 @@
-export type Coordinates = [number, number];

--- a/client/__tests__/service_tests/MapUtils-test.ts
+++ b/client/__tests__/service_tests/MapUtils-test.ts
@@ -1,0 +1,26 @@
+import { calculateEuclideanDistance } from '@/modules/map/MapUtils';
+
+describe('calculateEuclideanDistance', () => {
+  test('should accurately calculate the Euclidean distance between two points', () => {
+    const result = calculateEuclideanDistance([45.4509412, -73.6481951], [45.459564, -73.635818]);
+    expect(result).toBeCloseTo(0.01508, 5);
+  });
+
+  test('should return 0 when both points are the same', () => {
+    const result = calculateEuclideanDistance([45.4509412, -73.6481951], [45.4509412, -73.6481951]);
+    expect(result).toBe(0);
+  });
+
+  test('should correctly handle negative coordinates', () => {
+    const result = calculateEuclideanDistance([-10, -10], [-20, -20]);
+    expect(result).toBeCloseTo(14.1421, 4);
+  });
+
+  test('should correctly handle points along the same axis', () => {
+    const resultX = calculateEuclideanDistance([10, 0], [20, 0]);
+    expect(resultX).toBe(10);
+
+    const resultY = calculateEuclideanDistance([0, 10], [0, 20]);
+    expect(resultY).toBe(10);
+  });
+});

--- a/client/modules/map/MapContext.tsx
+++ b/client/modules/map/MapContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useRef, useState, useMemo } from 'react';
 import Mapbox from '@rnmapbox/maps';
 import { getRoute } from './MapService';
-import { Coordinates } from '@/Types/Coordinate';
+import { Coordinates } from './Types';
 
 export interface Location {
   name: string | null;

--- a/client/modules/map/MapService.tsx
+++ b/client/modules/map/MapService.tsx
@@ -1,5 +1,7 @@
 import ShuttleCalculatorService from '@/Services/ShuttleCalculatorService';
 import { Coordinates, Location } from './MapContext';
+import { calculateEuclideanDistance } from './MapUtils';
+
 const MAPBOX_ACCESS_TOKEN = process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 let GOOGLE_API_KEY = process.env.EXPO_PUBLIC_GOOGLEMAPS_API_KEY as string;
 
@@ -81,29 +83,6 @@ const fetchLocationData = async (coordinates: Coordinates) => {
   }
 };
 
-const distanceOf2Coords = async (coord1: Coordinates, coord2: Coordinates): Promise<number> => {
-  const origin = `${coord1[1]},${coord1[0]}`;
-  const destination = `${coord2[1]},${coord2[0]}`;
-
-  const url = `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${origin}&destinations=${destination}&key=${GOOGLE_API_KEY}`;
-
-  try {
-    const response = await fetch(url);
-    const data = await response.json();
-
-    if (data.status === 'OK' && data.rows[0].elements[0].status === 'OK') {
-      const distanceValue = data.rows[0].elements[0].distance.value;
-      return Number(distanceValue / 1000);
-    } else {
-      console.error('Error fetching distance:', data);
-      return -1;
-    }
-  } catch (error) {
-    console.error('Fetch error:', error);
-    return -1;
-  }
-};
-
 const getRouteForShuttle = async (
   startCoordinates: Coordinates,
   endCoordinates: Coordinates
@@ -112,7 +91,7 @@ const getRouteForShuttle = async (
   duration: number | null;
   distance: number | null;
 }> => {
-  const MAX_DISTANCE_FROM_BUS = 1.5;
+  const MAX_EUCLIDEAN_DISTANCE = 0.01508;
 
   const SgwCoords: Coordinates = [-73.5784711, 45.4970661];
   const LoyolaCoords: Coordinates = [-73.6393324, 45.4577857];
@@ -125,24 +104,27 @@ const getRouteForShuttle = async (
   let isEndSgw = false;
   let isEndLoyola = false;
 
-  const distanceToShuttleSgwFromStart = await distanceOf2Coords(SgwCoords, startCoordinates);
-  const distanceToShuttleLoyolaFromStart = await distanceOf2Coords(LoyolaCoords, startCoordinates);
-  const distanceToShuttleSgwFromEnd = await distanceOf2Coords(SgwCoords, endCoordinates);
-  const distanceToShuttleLoyolaFromEnd = await distanceOf2Coords(LoyolaCoords, endCoordinates);
+  const distanceToShuttleSgwFromStart = calculateEuclideanDistance(SgwCoords, startCoordinates);
+  const distanceToShuttleLoyolaFromStart = calculateEuclideanDistance(
+    LoyolaCoords,
+    startCoordinates
+  );
+  const distanceToShuttleSgwFromEnd = calculateEuclideanDistance(SgwCoords, endCoordinates);
+  const distanceToShuttleLoyolaFromEnd = calculateEuclideanDistance(LoyolaCoords, endCoordinates);
 
-  if (distanceToShuttleSgwFromStart <= MAX_DISTANCE_FROM_BUS) {
+  if (distanceToShuttleSgwFromStart <= MAX_EUCLIDEAN_DISTANCE) {
     isStartSgw = true;
     startBusStop = SgwCoords;
   }
-  if (distanceToShuttleLoyolaFromStart <= MAX_DISTANCE_FROM_BUS) {
+  if (distanceToShuttleLoyolaFromStart <= MAX_EUCLIDEAN_DISTANCE) {
     isStartLoyola = true;
     startBusStop = LoyolaCoords;
   }
-  if (distanceToShuttleSgwFromEnd <= MAX_DISTANCE_FROM_BUS) {
+  if (distanceToShuttleSgwFromEnd <= MAX_EUCLIDEAN_DISTANCE) {
     isEndSgw = true;
     endBusStop = SgwCoords;
   }
-  if (distanceToShuttleLoyolaFromEnd <= MAX_DISTANCE_FROM_BUS) {
+  if (distanceToShuttleLoyolaFromEnd <= MAX_EUCLIDEAN_DISTANCE) {
     isEndLoyola = true;
     endBusStop = LoyolaCoords;
   }

--- a/client/modules/map/MapUtils.tsx
+++ b/client/modules/map/MapUtils.tsx
@@ -1,0 +1,14 @@
+import { Coordinates } from './MapContext';
+
+/**
+ * Calculates the Euclidean distance between two points.
+ *
+ * @param start - The starting coordinates as a tuple [x, y].
+ * @param end - The ending coordinates as a tuple [x, y].
+ * @returns The Euclidean distance between the start and end coordinates.
+ */
+const calculateEuclideanDistance = (start: Coordinates, end: Coordinates): number => {
+  return Math.sqrt(Math.pow(start[0] - end[0], 2) + Math.pow(start[1] - end[1], 2));
+};
+
+export { calculateEuclideanDistance };

--- a/client/modules/map/Types.ts
+++ b/client/modules/map/Types.ts
@@ -1,0 +1,5 @@
+/*
+Internal representation of a pair of coordinates.
+Coordinates: [latitude, longitude]
+*/
+export type Coordinates = [number, number];


### PR DESCRIPTION
This PR replaces calls to Google's distance matrix API with a local Euclidean distance calculation.

We were using the return values of this API to make decisions based on whether the shuttle is a viable option, given the start and end location's distance to Concordia's shuttle stops. Since we would only proceed with shuttle-mode route calculations if the start / end locations were within 1.5 km (a relatively short distance) from a shuttle stop, it is reasonable (and more efficient) to use Euclidean distance as an approximation.

@cmezzac Given that you implemented the original functionality, can you test and review this PR?