### PR TITLE
Fix start / end location specification by tapping

### DIFF
--- a/client/app/(tabs)/index.tsx
+++ b/client/app/(tabs)/index.tsx
@@ -14,6 +14,7 @@ import CenterLocationComponent from '@/components/ui/IconCenterLocation';
 import { LocationInfo } from '@/components/LocationInfo';
 import { RoutePlanner } from '@/components/RoutePlanner';
 import ToggleCampusButton from '@/components/ui/ToggleCampusButton';
+import MapHint from '@/components/MapHint';
 
 export default function HomeScreen() {
   const { state } = useMap();
@@ -30,6 +31,7 @@ export default function HomeScreen() {
       {state === MapState.Idle && <CenterLocationComponent />}
       {state === MapState.Information && <LocationInfo />}
       {state === MapState.RoutePlanning && <RoutePlanner />}
+      <MapHint />
     </View>
   );
 }

--- a/client/components/LocationInput.tsx
+++ b/client/components/LocationInput.tsx
@@ -5,6 +5,8 @@ import { TextInput, View, StyleSheet, TouchableOpacity, Text } from 'react-nativ
 import LocationsAutocomplete from './LocationsAutocomplete';
 import CoordinateService from '@/Services/CoordinateService';
 
+const CURRENT_LOCATION_NAME = 'Current location';
+
 export default function LocationInput({
   location,
   setLocation,
@@ -24,21 +26,17 @@ export default function LocationInput({
   const { setState } = useMap();
 
   useEffect(() => {
-    if (location && !isFocused) {
+    if (location) {
       setQuery(location.name ?? '');
     }
-  }, [location, isFocused]);
+  }, [location]);
 
   const handleFocus = () => {
     setIsFocused(true);
-    setQuery('');
   };
 
   const handleBlur = () => {
     setIsFocused(false);
-    if (location) {
-      setQuery(location.name ?? '');
-    }
   };
 
   const handleCurrentLocation = async () => {
@@ -47,7 +45,7 @@ export default function LocationInput({
         const tempCoordinates = await CoordinateService.getCurrentCoordinates();
         if (tempCoordinates) {
           setLocation({
-            name: 'Current location',
+            name: CURRENT_LOCATION_NAME,
             coordinates: tempCoordinates,
           });
           inputRef.current?.blur();
@@ -100,7 +98,7 @@ export default function LocationInput({
             <Ionicons name="map-outline" size={20} color="#666" />
             <Text style={styles.optionText}>Choose on map</Text>
           </TouchableOpacity>
-          {isStartLocation && (
+          {isStartLocation && location?.name !== CURRENT_LOCATION_NAME && (
             <TouchableOpacity style={styles.optionItem} onPress={handleCurrentLocation}>
               <Ionicons name="locate-outline" size={20} color="#666" />
               <Text style={styles.optionText}>Use Current Location</Text>

--- a/client/components/MapHint.tsx
+++ b/client/components/MapHint.tsx
@@ -1,0 +1,42 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { useMap, MapState } from '@/modules/map/MapContext';
+
+function getHint(state: MapState): string | null {
+  switch (state) {
+    case MapState.SelectingStartLocation:
+      return 'Tap anywhere to set your start location';
+    case MapState.SelectingEndLocation:
+      return 'Tap anywhere to set your destination';
+    default:
+      return null;
+  }
+}
+
+export default function MapHint() {
+  const { state } = useMap();
+  const hint = getHint(state);
+  if (!hint) return null;
+  return (
+    <View style={styles.hintContainer}>
+      <Text style={styles.hintText}>{hint}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  hintContainer: {
+    position: 'absolute',
+    top: 140,
+    left: 20,
+    right: 20,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    padding: 12,
+    borderRadius: 8,
+    zIndex: 1000,
+  },
+  hintText: {
+    color: 'white',
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});

--- a/client/components/RoutePlanner.tsx
+++ b/client/components/RoutePlanner.tsx
@@ -32,7 +32,6 @@ export function RoutePlanner() {
     setStartLocation,
     endLocation,
     setEndLocation,
-    state,
   } = useMap();
 
   const centerMapOnUserLocation = async () => {

--- a/client/components/RoutePlanner.tsx
+++ b/client/components/RoutePlanner.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
 import { View, StyleSheet, Pressable, ScrollView, Text, Animated } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { MapState, useMap } from '@/modules/map/MapContext';
+import { Coordinates, MapState, useMap } from '@/modules/map/MapContext';
 import { getRoute, formatDuration } from '@/modules/map/MapService';
 import LocationInput from './LocationInput';
+import CoordinateService from '@/Services/CoordinateService';
 
 export function RoutePlanner() {
   const [durations, setDurations] = React.useState<{ [key: string]: number | null }>({
@@ -34,36 +35,25 @@ export function RoutePlanner() {
     state,
   } = useMap();
 
+  const centerMapOnUserLocation = async () => {
+    const tempCoordinates: Coordinates = (await CoordinateService.getCurrentCoordinates()) ?? [
+      0, 0,
+    ];
+
+    setStartLocation({
+      name: 'Current location',
+      coordinates: tempCoordinates,
+    });
+  };
+
   useEffect(() => {
-    console.log('RoutePlanner Effect - Triggered');
-    console.log('Start Location:', startLocation);
-    console.log('End Location:', endLocation);
-    console.log('Current State:', state);
-
-    if (state === MapState.RoutePlanning) {
-      if (endLocation) {
-        if (!startLocation) {
-          console.log('Start location not set, waiting for user input');
-        }
-      }
-      if (startLocation && endLocation) {
-        const loadRoute = async () => {
-          try {
-            await loadRouteFromCoordinates(
-              startLocation.coordinates,
-              endLocation.coordinates,
-              selectedMode
-            );
-            calculateOptions();
-          } catch (error) {
-            console.error('Error loading route:', error);
-          }
-        };
-
-        loadRoute();
-      }
+    if (!startLocation) {
+      centerMapOnUserLocation();
+    } else if (startLocation && endLocation) {
+      loadRouteFromCoordinates(startLocation.coordinates, endLocation.coordinates, selectedMode);
+      calculateOptions();
     }
-  }, [startLocation, endLocation, selectedMode, state]);
+  }, [startLocation, endLocation, selectedMode]);
 
   useEffect(() => {
     if (durations.shuttle == null && selectedMode == 'shuttle') {

--- a/client/modules/map/MapView.tsx
+++ b/client/modules/map/MapView.tsx
@@ -1,9 +1,8 @@
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Mapbox from '@rnmapbox/maps';
 import React from 'react';
 import { MapState, useMap } from './MapContext';
 import { fetchLocationData } from './MapService';
-import { LocationInfo } from '@/components/LocationInfo';
 
 Mapbox.setAccessToken(process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN as string);
 
@@ -78,87 +77,61 @@ export default function MapView() {
     }
   }
 
-  // pop up messaged to help guide user
-  function getHelperText() {
-    switch (state) {
-      case MapState.SelectingStartLocation:
-        return 'Tap anywhere on the map to set your start location';
-      case MapState.SelectingEndLocation:
-        return 'Tap anywhere on the map to set your destination';
-      case MapState.RoutePlanning:
-        return 'Tap input boxes to search by address or choose on map';
-      default:
-        return null;
-    }
-  }
-
   return (
-    <>
-      {getHelperText() && (
-        <View
-          style={[
-            styles.helperTextContainer,
-            state === MapState.RoutePlanning ? styles.routePlanningHelper : undefined,
-          ]}>
-          <Text style={styles.helperText}>{getHelperText()}</Text>
-        </View>
+    <Mapbox.MapView
+      ref={mapRef}
+      style={styles.map}
+      styleURL="mapbox://styles/ambrose821/cm6g7anat00kv01qmbxkze6i8"
+      onPress={onMapClick}>
+      <Mapbox.Camera
+        ref={cameraRef}
+        zoomLevel={zoomLevel}
+        centerCoordinate={centerCoordinate}
+        animationMode="flyTo"
+        animationDuration={2000}
+        pitch={pitchLevel}
+      />
+
+      {endLocation?.coordinates && (
+        <Mapbox.PointAnnotation
+          key="selected-location"
+          id="selected-location"
+          coordinate={[endLocation?.coordinates[0], endLocation?.coordinates[1]]}>
+          <View style={[styles.marker, styles.endMarker]} />
+          <Mapbox.Callout title="Selected Location" />
+        </Mapbox.PointAnnotation>
       )}
-      <Mapbox.MapView
-        ref={mapRef}
-        style={styles.map}
-        styleURL="mapbox://styles/ambrose821/cm6g7anat00kv01qmbxkze6i8"
-        onPress={onMapClick}>
-        <Mapbox.Camera
-          ref={cameraRef}
-          zoomLevel={zoomLevel}
-          centerCoordinate={centerCoordinate}
-          animationMode="flyTo"
-          animationDuration={2000}
-          pitch={pitchLevel}
-        />
 
-        {endLocation?.coordinates && (
-          <Mapbox.PointAnnotation
-            key="selected-location"
-            id="selected-location"
-            coordinate={[endLocation?.coordinates[0], endLocation?.coordinates[1]]}>
-            <View style={[styles.marker, styles.endMarker]} />
-            <Mapbox.Callout title="Selected Location" />
-          </Mapbox.PointAnnotation>
-        )}
-
-        {state === MapState.RoutePlanning && startLocation !== null && endLocation !== null && (
-          <>
-            <Mapbox.MarkerView id="start" coordinate={startLocation.coordinates}>
-              <View style={[styles.marker, styles.startMarker]} />
-            </Mapbox.MarkerView>
-            {routeCoordinates.length > 0 && (
-              <Mapbox.ShapeSource
-                id="routeSource"
-                shape={{
-                  type: 'Feature',
-                  properties: {},
-                  geometry: {
-                    type: 'LineString',
-                    coordinates: routeCoordinates,
-                  },
-                }}>
-                <Mapbox.LineLayer
-                  id="routeFill"
-                  style={{
-                    lineColor: '#007AFF',
-                    lineWidth: 4,
-                    lineCap: 'round',
-                    lineJoin: 'round',
-                  }}
-                />
-              </Mapbox.ShapeSource>
-            )}
-          </>
-        )}
-      </Mapbox.MapView>
-      {state === MapState.Information && <LocationInfo />}
-    </>
+      {state === MapState.RoutePlanning && startLocation !== null && endLocation !== null && (
+        <>
+          <Mapbox.MarkerView id="start" coordinate={startLocation.coordinates}>
+            <View style={[styles.marker, styles.startMarker]} />
+          </Mapbox.MarkerView>
+          {routeCoordinates.length > 0 && (
+            <Mapbox.ShapeSource
+              id="routeSource"
+              shape={{
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                  type: 'LineString',
+                  coordinates: routeCoordinates,
+                },
+              }}>
+              <Mapbox.LineLayer
+                id="routeFill"
+                style={{
+                  lineColor: '#007AFF',
+                  lineWidth: 4,
+                  lineCap: 'round',
+                  lineJoin: 'round',
+                }}
+              />
+            </Mapbox.ShapeSource>
+          )}
+        </>
+      )}
+    </Mapbox.MapView>
   );
 }
 
@@ -181,23 +154,8 @@ const styles = StyleSheet.create({
   endMarker: {
     backgroundColor: '#852C3A',
   },
-  helperTextContainer: {
-    position: 'absolute',
-    top: 140,
-    left: 20,
-    right: 20,
-    backgroundColor: 'rgba(0, 0, 0, 0.7)',
-    padding: 12,
-    borderRadius: 8,
-    zIndex: 1000,
-  },
   routePlanningHelper: {
     top: 300,
     backgroundColor: 'rgba(0, 0, 0, 0.7)',
-  },
-  helperText: {
-    color: 'white',
-    fontSize: 16,
-    textAlign: 'center',
   },
 });


### PR DESCRIPTION
These changes are to reconcile behaviour issues with [17-us-21-NEW-selecting-a-building-for-start-and-destination-locations](https://github.com/mahutt/ViniMap/tree/17-us-21-NEW-selecting-a-building-for-start-and-destination-locations). The key changes are listed below.

- A `LocationInput` field no longer clears itself when focused - this may be re-implemented once we have an intuitive way to cancel an edit to the start or end location value.
- The start location is automatically set to the user's current location by default, as is the case on `main`.
- `LocationInfo` and `MapHint` rendering logic has been moved out of `MapView` to maintain separation of concerns.

These changes were pushed to a separate branch so that they could be tried without committing them.