### PR TITLE
fixing android icons in IconSymbol.tsx

### DIFF
--- a/client/components/ui/IconSymbol.tsx
+++ b/client/components/ui/IconSymbol.tsx
@@ -3,7 +3,7 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { SymbolWeight } from 'expo-symbols';
 import React from 'react';
-import { OpaqueColorValue, StyleProp, ViewStyle } from 'react-native';
+import { OpaqueColorValue, StyleProp, TextStyle } from 'react-native';
 
 // Add your SFSymbol to MaterialIcons mappings here.
 const MAPPING = {
@@ -12,7 +12,11 @@ const MAPPING = {
   'house.fill': 'home',
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
+  // for android bottom bar icons
   'chevron.right': 'chevron-right',
+  'map.fill': 'map',
+  calendar: 'calendar-today',
+  gear: 'settings',
 } as Partial<
   Record<
     import('expo-symbols').SymbolViewProps['name'],
@@ -36,7 +40,7 @@ export function IconSymbol({
   name: IconSymbolName;
   size?: number;
   color: string | OpaqueColorValue;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<TextStyle>;
   weight?: SymbolWeight;
 }) {
   return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;

--- a/client/components/ui/IconSymbol.tsx
+++ b/client/components/ui/IconSymbol.tsx
@@ -5,15 +5,7 @@ import { SymbolWeight } from 'expo-symbols';
 import React from 'react';
 import { OpaqueColorValue, StyleProp, TextStyle } from 'react-native';
 
-// Add your SFSymbol to MaterialIcons mappings here.
 const MAPPING = {
-  // See MaterialIcons here: https://icons.expo.fyi
-  // See SF Symbols in the SF Symbols app on Mac.
-  'house.fill': 'home',
-  'paperplane.fill': 'send',
-  'chevron.left.forwardslash.chevron.right': 'code',
-  // for android bottom bar icons
-  'chevron.right': 'chevron-right',
   'map.fill': 'map',
   calendar: 'calendar-today',
   gear: 'settings',


### PR DESCRIPTION
Addressing this ticket: [https://github.com/mahutt/ViniMap/issues/131](url)

### What has changed:

  * Adding mapping for the android icons: Map, Calendar, Settings.

What to test:

  * I need at least 1 mac user and 1 windows user to test how the icons look like on their respective devices.

**TO BE MERGED AT THE START OF SPRINT 4!!**

![image](https://github.com/user-attachments/assets/793ad455-aeb8-4cfb-b200-9b73bf7488a5)
