### PR TITLE
Minor Visual Improvements + snapshot tests for ToggleCampusButton

### DIFF
--- a/client/__tests__/component_tests/ToggleCampusButton-test.tsx
+++ b/client/__tests__/component_tests/ToggleCampusButton-test.tsx
@@ -1,0 +1,87 @@
+import { render, fireEvent } from '@testing-library/react-native';
+import ToggleCampusButton from '@/components/ui/ToggleCampusButton';
+import { MapProvider, useMap } from '@/modules/map/MapContext';
+import React from 'react';
+
+jest.mock('@/modules/map/MapContext', () => {
+  const flyToMock = jest.fn();
+
+  return {
+    MapProvider: ({ children }: { children: React.ReactNode }) => children,
+
+    useMap: () => ({
+      flyTo: flyToMock,
+    }),
+  };
+});
+
+describe('<ToggleCampusButton />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('ToggleCampusButton renders correctly', () => {
+    const tree = render(
+      <MapProvider>
+        <ToggleCampusButton />
+      </MapProvider>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('Default selected location is SGW', () => {
+    const { getByText } = render(
+      <MapProvider>
+        <ToggleCampusButton />
+      </MapProvider>
+    );
+
+    const sgwButton = getByText('SGW').parent;
+    const loyButton = getByText('LOY').parent;
+
+    expect(sgwButton.props.style).toContainEqual({ backgroundColor: '#800000' });
+    expect(loyButton.props.style).not.toContainEqual({ backgroundColor: '#800000' });
+  });
+
+  test('Clicking LOY button calls flyTo with LOY coordinates', () => {
+    const { getByText } = render(
+      <MapProvider>
+        <ToggleCampusButton />
+      </MapProvider>
+    );
+
+    fireEvent.press(getByText('LOY'));
+
+    const { flyTo } = useMap();
+
+    expect(flyTo).toHaveBeenCalledWith([-73.6391, 45.4581]);
+
+    const loyButton = getByText('LOY').parent;
+    expect(loyButton.props.style).toContainEqual({ backgroundColor: '#800000' });
+
+    const sgwButton = getByText('SGW').parent;
+    expect(sgwButton.props.style).not.toContainEqual({ backgroundColor: '#800000' });
+  });
+
+  test('Clicking SGW button after LOY calls flyTo with SGW coordinates', () => {
+    const { getByText } = render(
+      <MapProvider>
+        <ToggleCampusButton />
+      </MapProvider>
+    );
+
+    fireEvent.press(getByText('LOY'));
+
+    fireEvent.press(getByText('SGW'));
+
+    const { flyTo } = useMap();
+
+    expect(flyTo).toHaveBeenNthCalledWith(2, [-73.5789, 45.4973]);
+
+    const sgwButton = getByText('SGW').parent;
+    expect(sgwButton.props.style).toContainEqual({ backgroundColor: '#800000' });
+
+    const loyButton = getByText('LOY').parent;
+    expect(loyButton.props.style).not.toContainEqual({ backgroundColor: '#800000' });
+  });
+});

--- a/client/__tests__/component_tests/ToggleCampusButton-test.tsx
+++ b/client/__tests__/component_tests/ToggleCampusButton-test.tsx
@@ -20,7 +20,7 @@ jest.mock('@/modules/map/MapContext', () => {
 });
 
 const isTextActive = (textElement: any): boolean => {
-  if (!textElement || !textElement.props || !textElement.props.style) {
+  if (!textElement?.props?.style) {
     return false;
   }
 

--- a/client/__tests__/component_tests/__snapshots__/ToggleCampusButton-test.tsx.snap
+++ b/client/__tests__/component_tests/__snapshots__/ToggleCampusButton-test.tsx.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ToggleCampusButton /> ToggleCampusButton renders correctly 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": "#f3f3f3",
+        "borderColor": "#800000",
+        "borderRadius": 25,
+        "borderWidth": 2,
+        "elevation": 5,
+        "flexDirection": "row",
+        "height": 30,
+        "justifyContent": "center",
+        "padding": 3,
+        "position": "absolute",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.2,
+        "shadowRadius": 4,
+        "width": 138,
+        "zIndex": 2,
+      },
+      {
+        "left": 39,
+        "right": 20,
+        "top": 125,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "borderRadius": 25,
+        "flex": 1,
+        "justifyContent": "center",
+        "opacity": 1,
+        "paddingHorizontal": 16,
+        "paddingVertical": 3,
+      }
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "color": "#800000",
+            "fontSize": 10,
+            "fontWeight": "bold",
+          },
+          null,
+        ]
+      }
+    >
+      LOY
+    </Text>
+  </View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#800000",
+        "borderRadius": 25,
+        "flex": 1,
+        "justifyContent": "center",
+        "opacity": 1,
+        "paddingHorizontal": 16,
+        "paddingVertical": 3,
+      }
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "color": "#800000",
+            "fontSize": 10,
+            "fontWeight": "bold",
+          },
+          {
+            "color": "white",
+          },
+        ]
+      }
+    >
+      SGW
+    </Text>
+  </View>
+</View>
+`;

--- a/client/app/(tabs)/_layout.tsx
+++ b/client/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, View, StyleSheet } from 'react-native';
 
 //keep ../../comp... b/c it is needed to compile on irl iphone
 import { HapticTab } from '../../components/HapticTab';
@@ -11,15 +11,27 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { MapProvider } from '@/modules/map/MapContext';
 
 const TabBarMapIcon = ({ color }: { color: string }) => {
-  return <IconSymbol size={28} name="map.fill" color={color} />;
+  return (
+    <View style={styles.iconContainer}>
+      <IconSymbol size={28} name="map.fill" color={color} />
+    </View>
+  );
 };
 
 const TabBarCalendarIcon = ({ color }: { color: string }) => {
-  return <IconSymbol size={28} name="calendar" color={color} />;
+  return (
+    <View style={styles.iconContainer}>
+      <IconSymbol size={28} name="calendar" color={color} />
+    </View>
+  );
 };
 
 const TabBarSettingsIcon = ({ color }: { color: string }) => {
-  return <IconSymbol size={28} name="gear" color={color} />;
+  return (
+    <View style={styles.iconContainer}>
+      <IconSymbol size={28} name="gear" color={color} />
+    </View>
+  );
 };
 
 const TabLayout = ({ colorScheme }: { colorScheme: 'light' | 'dark' }) => (
@@ -33,9 +45,19 @@ const TabLayout = ({ colorScheme }: { colorScheme: 'light' | 'dark' }) => (
         tabBarStyle: Platform.select({
           ios: {
             position: 'absolute',
+            height: 80,
+            paddingBottom: 20,
           },
-          default: {},
+          default: {
+            height: 70,
+            paddingTop: 10,
+            paddingBottom: 10,
+          },
         }),
+        tabBarItemStyle: {
+          height: '100%',
+          justifyContent: 'center',
+        },
       }}>
       <Tabs.Screen
         name="index"
@@ -61,6 +83,14 @@ const TabLayout = ({ colorScheme }: { colorScheme: 'light' | 'dark' }) => (
     </Tabs>
   </MapProvider>
 );
+
+const styles = StyleSheet.create({
+  iconContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+});
 
 export default function App() {
   const colorScheme = useColorScheme();

--- a/client/components/ui/RoutePlanner Components/BottomFrame.tsx
+++ b/client/components/ui/RoutePlanner Components/BottomFrame.tsx
@@ -47,7 +47,7 @@ const styles = StyleSheet.create({
     padding: 30,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
-    height: '20%',
+    height: '25%',
     justifyContent: 'flex-start',
     alignItems: 'flex-start',
     bottom: 0,

--- a/client/components/ui/RoutePlanner Components/BottomFrame.tsx
+++ b/client/components/ui/RoutePlanner Components/BottomFrame.tsx
@@ -38,17 +38,19 @@ export function BottomFrame({ selectedMode, modeIcon, durations, distances }: Bo
     </Animated.View>
   );
 }
+
 const styles = StyleSheet.create({
   infoContainer: {
     position: 'absolute',
-    bottom: 20,
     zIndex: 10,
     backgroundColor: 'white',
     padding: 30,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
-    height: 180,
+    height: '20%',
+    justifyContent: 'flex-start',
     alignItems: 'flex-start',
+    bottom: 0,
   },
   boldText: {
     fontWeight: 'bold',
@@ -87,4 +89,5 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
+
 export default BottomFrame;

--- a/client/components/ui/ToggleCampusButton.tsx
+++ b/client/components/ui/ToggleCampusButton.tsx
@@ -49,7 +49,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: '#f3f3f3',
     borderRadius: 25,
-    padding: 5,
+    padding: 3,
+    height: 30,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
@@ -63,14 +64,14 @@ const styles = StyleSheet.create({
   },
   button: {
     flex: 1,
-    paddingVertical: 2,
+    paddingVertical: 3,
     paddingHorizontal: 16,
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 25,
   },
   activeButton: {
-    backgroundColor: 'white',
+    backgroundColor: '#800000',
   },
   text: {
     fontSize: 10,
@@ -78,7 +79,7 @@ const styles = StyleSheet.create({
     color: '#800000',
   },
   activeText: {
-    color: '#800000',
+    color: 'white',
   },
   toggleButton: {
     top: 125,


### PR DESCRIPTION
## Snapshot test achieves full statement, branch and line coverage, active part of transport button is higher contrast:
### Old Button:
![image](https://github.com/user-attachments/assets/cdf64422-3a63-4c8f-ad05-58ede6660fdf)

### New Button:
![image](https://github.com/user-attachments/assets/8e74c4d2-329d-422f-baae-61b503798a0e)

## Increased size of the NavBar for Android devices:
### Old Navbar:
![image](https://github.com/user-attachments/assets/af72d560-0945-44c3-98ff-75d54233a3cb)

### New Navbar:
![image](https://github.com/user-attachments/assets/6bb7620b-4132-4ae6-b8b9-cb2c781e020e)

## Removed Gap below Bottom Frame in Route Planning state:
### Old Bottom frame:
![image](https://github.com/user-attachments/assets/a5d137f8-f7e5-4c0c-bb66-8c5ffc7cea31)

### New Bottom Frame:
![image](https://github.com/user-attachments/assets/d45abb45-8748-45be-bf7e-9efb34843d90)
