### PR TITLE
156 fix fetching the current location from expo

### DIFF
--- a/client/app.json
+++ b/client/app.json
@@ -10,22 +10,12 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.client",
-      "infoPlist": {
-        "NSLocationWhenInUseUsageDescription": "This app needs access to your location.",
-        "NSLocationAlwaysAndWhenInUseUsageDescription": "This app needs access to your location."
-      }
+      "bundleIdentifier": "com.anonymous.client"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
-        "backgroundColor": "#ffffff",
-        "package": "com.anonymous.client",
-        "permissions": [
-          "android.permission.ACCESS_COARSE_LOCATION",
-          "android.permission.ACCESS_FINE_LOCATION",
-          "android.permission.FOREGROUND_SERVICE"
-        ]
+        "backgroundColor": "#ffffff"
       },
       "package": "com.anonymous.client"
     },
@@ -49,12 +39,6 @@
         "@rnmapbox/maps",
         {
           "RNMapboxMapsImpl": "mapbox"
-        }
-      ],
-      [
-        "expo-location",
-        {
-          "locationAlwaysAndWhenInUsePermission": "Allow $(PRODUCT_NAME) to use your location."
         }
       ]
     ],

--- a/client/app.json
+++ b/client/app.json
@@ -10,12 +10,22 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.client"
+      "bundleIdentifier": "com.anonymous.client",
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "This app needs access to your location.",
+        "NSLocationAlwaysAndWhenInUseUsageDescription": "This app needs access to your location."
+      }
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
+        "backgroundColor": "#ffffff",
+        "package": "com.anonymous.client",
+        "permissions": [
+          "android.permission.ACCESS_COARSE_LOCATION",
+          "android.permission.ACCESS_FINE_LOCATION",
+          "android.permission.FOREGROUND_SERVICE"
+        ]
       },
       "package": "com.anonymous.client"
     },
@@ -39,6 +49,12 @@
         "@rnmapbox/maps",
         {
           "RNMapboxMapsImpl": "mapbox"
+        }
+      ],
+      [
+        "expo-location",
+        {
+          "locationAlwaysAndWhenInUsePermission": "Allow $(PRODUCT_NAME) to use your location."
         }
       ]
     ],

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -24,7 +24,7 @@ export default class CoordinateService {
 
       const { latitude, longitude } = currentLocation.coords;
       return [longitude, latitude];
-    } catch (error) {
+    } catch {
       if (Platform.OS === 'android') {
         return [45.496067, -73.569315];
       }

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -1,4 +1,5 @@
 import * as Location from 'expo-location';
+import { Platform } from 'react-native';
 
 type Coordinates = [number, number];
 
@@ -11,12 +12,23 @@ export default class CoordinateService {
         return null;
       }
 
-      const currentLocation = await Location.getCurrentPositionAsync({});
+      const locationPromise = Location.getCurrentPositionAsync({});
+      const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('')), 2000);
+      });
+
+      const currentLocation = (await Promise.race([
+        locationPromise,
+        timeoutPromise,
+      ])) as Location.LocationObject;
 
       const { latitude, longitude } = currentLocation.coords;
       return [longitude, latitude];
     } catch (error) {
-      console.error('Error getting current location:', error);
+      if (Platform.OS === 'android') {
+        return [45.496067, -73.569315];
+      }
+
       return null;
     }
   }

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -1,5 +1,4 @@
 import * as Location from 'expo-location';
-import { Platform } from 'react-native';
 
 type Coordinates = [number, number];
 
@@ -25,11 +24,7 @@ export default class CoordinateService {
       const { latitude, longitude } = currentLocation.coords;
       return [longitude, latitude];
     } catch {
-      if (Platform.OS === 'android') {
-        return [45.496067, -73.569315];
-      }
-
-      return null;
+      return [45.496067, -73.569315];
     }
   }
 }

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -14,7 +14,7 @@ export default class CoordinateService {
 
       const locationPromise = Location.getCurrentPositionAsync({});
       const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('')), 2000);
+        setTimeout(() => reject(new Error('')), 3000);
       });
 
       const currentLocation = (await Promise.race([


### PR DESCRIPTION
### Addressing the Current Location problem:

The android emulator has limitations in its location fetching capabilities, therefore the Current Location must be tested on a physical android device. I have tested it on my Google Pixel, and the Current Location works, it is auto-inputted into the start location.

To mediate this problem on the android emulator, here is my proposition: we hardcode the fallback coordinates for android in `CoordinateService.tsx`. 

### Here is what happens in `CoordinateService.tsx` now:

  * Requests location permissions
  * Sets 3-second timeout
  * Returns coordinates or null if location can't be fetched
  * Provides a hardcoded fallback location for Android and iOS (Bell Center)


The changes in the `app.json` file were reverted, they are not necessary since they do not fix the android emulator issues.
