### PR TITLE
Refactor IconCenterLocation so it calls CoordinateService

### DIFF
--- a/client/__tests__/component_tests/IconCenterLocation-test.tsx
+++ b/client/__tests__/component_tests/IconCenterLocation-test.tsx
@@ -5,9 +5,7 @@ import { useMap } from '@/modules/map/MapContext';
 import * as Location from 'expo-location';
 import CoordinateService from '@/services/CoordinateService';
 
-const getCurrentCoordinatesSpy = jest
-  .spyOn(CoordinateService, 'getCurrentCoordinates')
-  .mockResolvedValue([45.5017, -73.5673]);
+jest.spyOn(CoordinateService, 'getCurrentCoordinates').mockResolvedValue([45.5017, -73.5673]);
 
 jest.mock('@/modules/map/MapContext', () => ({
   useMap: jest.fn(),

--- a/client/__tests__/component_tests/IconCenterLocation-test.tsx
+++ b/client/__tests__/component_tests/IconCenterLocation-test.tsx
@@ -3,6 +3,11 @@ import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import CenterLocationComponent from '@/components/ui/IconCenterLocation';
 import { useMap } from '@/modules/map/MapContext';
 import * as Location from 'expo-location';
+import CoordinateService from '@/services/CoordinateService';
+
+const getCurrentCoordinatesSpy = jest
+  .spyOn(CoordinateService, 'getCurrentCoordinates')
+  .mockResolvedValue([45.5017, -73.5673]);
 
 jest.mock('@/modules/map/MapContext', () => ({
   useMap: jest.fn(),
@@ -53,10 +58,8 @@ describe('CenterLocationComponent', () => {
     fireEvent.press(button);
 
     await waitFor(() => {
-      expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalled();
-      expect(Location.getCurrentPositionAsync).toHaveBeenCalled();
-      expect(setCenterCoordinateMock).toHaveBeenCalledWith([-73.5673, 45.5017]);
-      expect(flyToMock).toHaveBeenCalledWith([-73.5673, 45.5017]);
+      expect(CoordinateService.getCurrentCoordinates).toHaveBeenCalled();
+      expect(flyToMock).toHaveBeenCalledWith([45.5017, -73.5673]);
     });
   });
 });

--- a/client/__tests__/service_tests/CoordinateService-test.tsx
+++ b/client/__tests__/service_tests/CoordinateService-test.tsx
@@ -45,13 +45,13 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toEqual([-122.4194, 37.7749]);
+    expect(coordinates).toEqual([37.7749, -122.4194]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledWith({});
   });
 
-  it('should return null when permissions are denied', async () => {
+  it('should return fallback coordinates when permissions are denied', async () => {
     // Mock permissions being denied
     mockedLocation.requestForegroundPermissionsAsync.mockResolvedValue({
       status: Location.PermissionStatus.DENIED,
@@ -62,12 +62,12 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toBeNull();
+    expect(coordinates).toEqual([45.494836, -73.577913]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).not.toHaveBeenCalled();
   });
 
-  it('should return null when Location.getCurrentPositionAsync throws an error', async () => {
+  it('should return fallback coordinates when Location.getCurrentPositionAsync throws an error', async () => {
     // Mock permissions granted but getCurrentPositionAsync throws
     mockedLocation.requestForegroundPermissionsAsync.mockResolvedValue({
       status: Location.PermissionStatus.GRANTED,
@@ -82,12 +82,12 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toEqual([45.496067, -73.569315]);
+    expect(coordinates).toEqual([45.494836, -73.577913]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('should return null when Location.requestForegroundPermissionsAsync throws an error', async () => {
+  it('should return fallback coordinates when Location.requestForegroundPermissionsAsync throws an error', async () => {
     // Mock requestForegroundPermissionsAsync throwing an error
     mockedLocation.requestForegroundPermissionsAsync.mockRejectedValue(
       new Error('Permission error')
@@ -95,7 +95,7 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toEqual([45.496067, -73.569315]);
+    expect(coordinates).toEqual([45.494836, -73.577913]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).not.toHaveBeenCalled();
   });

--- a/client/__tests__/service_tests/CoordinateService-test.tsx
+++ b/client/__tests__/service_tests/CoordinateService-test.tsx
@@ -35,7 +35,7 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toEqual([37.7749, -122.4194]);
+    expect(coordinates).toEqual([-122.4194, 37.7749]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledWith({});

--- a/client/__tests__/service_tests/CoordinateService-test.tsx
+++ b/client/__tests__/service_tests/CoordinateService-test.tsx
@@ -1,30 +1,20 @@
 import CoordinateService from '@/services/CoordinateService';
 import * as Location from 'expo-location';
 
-jest.useFakeTimers();
-
 // Mock the entire expo-location module
 jest.mock('expo-location');
 
 const mockedLocation = Location as jest.Mocked<typeof Location>;
 
-afterEach(() => {
-  jest.clearAllTimers();
-});
-
 describe('CoordinateService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    console.error = jest.fn();
-    jest.clearAllMocks();
-    console.error = jest.fn();
-    jest.clearAllTimers();
   });
 
   it('should return coordinates when permissions are granted', async () => {
     // Mock the required Location methods with successful responses
     mockedLocation.requestForegroundPermissionsAsync.mockResolvedValue({
-      status: Location.PermissionStatus.GRANTED,
+      status: 'granted' as Location.PermissionStatus,
       granted: true,
       expires: 'never',
       canAskAgain: true,
@@ -54,7 +44,7 @@ describe('CoordinateService', () => {
   it('should return fallback coordinates when permissions are denied', async () => {
     // Mock permissions being denied
     mockedLocation.requestForegroundPermissionsAsync.mockResolvedValue({
-      status: Location.PermissionStatus.DENIED,
+      status: 'denied' as Location.PermissionStatus,
       granted: false,
       expires: 'never',
       canAskAgain: true,
@@ -70,15 +60,13 @@ describe('CoordinateService', () => {
   it('should return fallback coordinates when Location.getCurrentPositionAsync throws an error', async () => {
     // Mock permissions granted but getCurrentPositionAsync throws
     mockedLocation.requestForegroundPermissionsAsync.mockResolvedValue({
-      status: Location.PermissionStatus.GRANTED,
+      status: 'granted' as Location.PermissionStatus,
       granted: true,
       expires: 'never',
       canAskAgain: true,
     });
 
-    mockedLocation.getCurrentPositionAsync.mockImplementation(() => {
-      throw new Error('Location error');
-    });
+    mockedLocation.getCurrentPositionAsync.mockRejectedValue(new Error('Location error'));
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 

--- a/client/__tests__/service_tests/CoordinateService-test.tsx
+++ b/client/__tests__/service_tests/CoordinateService-test.tsx
@@ -52,7 +52,7 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toEqual([45.494836, -73.577913]);
+    expect(coordinates).toEqual([-73.577913, 45.494836]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).not.toHaveBeenCalled();
   });
@@ -70,7 +70,7 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toEqual([45.494836, -73.577913]);
+    expect(coordinates).toEqual([-73.577913, 45.494836]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).toHaveBeenCalledTimes(1);
   });
@@ -83,7 +83,7 @@ describe('CoordinateService', () => {
 
     const coordinates = await CoordinateService.getCurrentCoordinates();
 
-    expect(coordinates).toEqual([45.494836, -73.577913]);
+    expect(coordinates).toEqual([-73.577913, 45.494836]);
     expect(mockedLocation.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1);
     expect(mockedLocation.getCurrentPositionAsync).not.toHaveBeenCalled();
   });

--- a/client/components/ui/IconCenterLocation.tsx
+++ b/client/components/ui/IconCenterLocation.tsx
@@ -9,7 +9,7 @@ const CenterLocationComponent = () => {
 
   const handlePress = async () => {
     const coordinates = await CoordinateService.getCurrentCoordinates();
-    const mapboxCoordinates: [number, number] = [coordinates[1], coordinates[0]];
+    const mapboxCoordinates: [number, number] = [coordinates[0], coordinates[1]];
 
     setCenterCoordinate(mapboxCoordinates);
     flyTo(mapboxCoordinates);

--- a/client/components/ui/IconCenterLocation.tsx
+++ b/client/components/ui/IconCenterLocation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, View, StyleSheet, Alert } from 'react-native';
+import { TouchableOpacity, View, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useMap } from '@/modules/map/MapContext';
 import CoordinateService from '@/services/CoordinateService';
@@ -8,15 +8,11 @@ const CenterLocationComponent = () => {
   const { flyTo, setCenterCoordinate } = useMap();
 
   const handlePress = async () => {
-    try {
-      const coordinates = await CoordinateService.getCurrentCoordinates();
-      const mapboxCoordinates: [number, number] = [coordinates[1], coordinates[0]];
+    const coordinates = await CoordinateService.getCurrentCoordinates();
+    const mapboxCoordinates: [number, number] = [coordinates[1], coordinates[0]];
 
-      setCenterCoordinate(mapboxCoordinates);
-      flyTo(mapboxCoordinates);
-    } catch (error) {
-      Alert.alert('Location Error', 'Cannot fetch location');
-    }
+    setCenterCoordinate(mapboxCoordinates);
+    flyTo(mapboxCoordinates);
   };
 
   return (

--- a/client/components/ui/IconCenterLocation.tsx
+++ b/client/components/ui/IconCenterLocation.tsx
@@ -1,28 +1,22 @@
 import React from 'react';
-import { TouchableOpacity, View, StyleSheet } from 'react-native';
+import { TouchableOpacity, View, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useMap } from '@/modules/map/MapContext';
-import * as Location from 'expo-location';
+import CoordinateService from '@/services/CoordinateService';
 
 const CenterLocationComponent = () => {
-  let currentLongitude = 0;
-  let currentLatitude = 0;
-  const { flyTo } = useMap();
-  const getPermissions = async () => {
-    let { status } = await Location.requestForegroundPermissionsAsync();
-    if (status !== 'granted') {
-      console.log('Please grant location permissions');
-      return;
-    }
-    let currentLocation = await Location.getCurrentPositionAsync({});
-    currentLatitude = currentLocation.coords.latitude;
-    currentLongitude = currentLocation.coords.longitude;
-  };
-  const { setCenterCoordinate } = useMap();
+  const { flyTo, setCenterCoordinate } = useMap();
+
   const handlePress = async () => {
-    await getPermissions();
-    setCenterCoordinate([currentLatitude, currentLongitude]);
-    flyTo([currentLongitude, currentLatitude]);
+    try {
+      const coordinates = await CoordinateService.getCurrentCoordinates();
+      const mapboxCoordinates: [number, number] = [coordinates[1], coordinates[0]];
+
+      setCenterCoordinate(mapboxCoordinates);
+      flyTo(mapboxCoordinates);
+    } catch (error) {
+      Alert.alert('Location Error', 'Cannot fetch location');
+    }
   };
 
   return (

--- a/client/components/ui/IconCenterLocation.tsx
+++ b/client/components/ui/IconCenterLocation.tsx
@@ -17,7 +17,7 @@ const CenterLocationComponent = () => {
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity style={styles.button} onPress={handlePress}>
+      <TouchableOpacity testID="center-location-button" style={styles.button} onPress={handlePress}>
         <Ionicons name="locate" size={24} color="white" />
       </TouchableOpacity>
     </View>

--- a/client/components/ui/IconCenterLocation.tsx
+++ b/client/components/ui/IconCenterLocation.tsx
@@ -5,14 +5,11 @@ import { useMap } from '@/modules/map/MapContext';
 import CoordinateService from '@/services/CoordinateService';
 
 const CenterLocationComponent = () => {
-  const { flyTo, setCenterCoordinate } = useMap();
+  const { flyTo } = useMap();
 
   const handlePress = async () => {
     const coordinates = await CoordinateService.getCurrentCoordinates();
-    const mapboxCoordinates: [number, number] = [coordinates[0], coordinates[1]];
-
-    setCenterCoordinate(mapboxCoordinates);
-    flyTo(mapboxCoordinates);
+    flyTo(coordinates);
   };
 
   return (

--- a/client/modules/map/Types.ts
+++ b/client/modules/map/Types.ts
@@ -1,6 +1,6 @@
 /*
 Internal representation of a pair of coordinates.
-Coordinates: [latitude, longitude]
+Coordinates: [longitude, latitude]
 */
 export type Coordinates = [number, number];
 

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -8,7 +8,7 @@ export default class CoordinateService {
       const { status } = await Location.requestForegroundPermissionsAsync();
 
       if (status !== 'granted') {
-        return [45.494836, -73.577913];
+        return [-73.577913, 45.494836];
       }
 
       const locationPromise = Location.getCurrentPositionAsync({});
@@ -22,9 +22,10 @@ export default class CoordinateService {
       ])) as Location.LocationObject;
 
       const { latitude, longitude } = currentLocation.coords;
+      console.log('Current location:', latitude, longitude);
       return [longitude, latitude];
     } catch {
-      return [45.494836, -73.577913];
+      return [-73.577913, 45.494836];
     }
   }
 }

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -22,7 +22,7 @@ export default class CoordinateService {
       ])) as Location.LocationObject;
 
       const { latitude, longitude } = currentLocation.coords;
-      return [latitude, longitude];
+      return [longitude, latitude];
     } catch {
       return [45.494836, -73.577913];
     }

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -3,17 +3,17 @@ import * as Location from 'expo-location';
 type Coordinates = [number, number];
 
 export default class CoordinateService {
-  static async getCurrentCoordinates(): Promise<Coordinates | null> {
+  static async getCurrentCoordinates(): Promise<Coordinates> {
     try {
       const { status } = await Location.requestForegroundPermissionsAsync();
 
       if (status !== 'granted') {
-        return null;
+        return [45.494836, -73.577913];
       }
 
       const locationPromise = Location.getCurrentPositionAsync({});
       const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('')), 3000);
+        setTimeout(() => reject(new Error('Location retrieval timeout')), 3000);
       });
 
       const currentLocation = (await Promise.race([
@@ -22,9 +22,9 @@ export default class CoordinateService {
       ])) as Location.LocationObject;
 
       const { latitude, longitude } = currentLocation.coords;
-      return [longitude, latitude];
+      return [latitude, longitude];
     } catch {
-      return [45.496067, -73.569315];
+      return [45.494836, -73.577913];
     }
   }
 }

--- a/client/services/CoordinateService.tsx
+++ b/client/services/CoordinateService.tsx
@@ -22,7 +22,6 @@ export default class CoordinateService {
       ])) as Location.LocationObject;
 
       const { latitude, longitude } = currentLocation.coords;
-      console.log('Current location:', latitude, longitude);
       return [longitude, latitude];
     } catch {
       return [-73.577913, 45.494836];


### PR DESCRIPTION
### Changes in this PR:

  * Refactor IconCenterLocation so it calls CoordinateService
  * Ensures CoordinateService always returns a fallback coords
  * Fixed problem with explicit type conversion for Mapbox coordinates
  * Added coordinate transformation to match Mapbox expectation (otherwise it would throw you to Antarctica)

Tested on my Android emulator and my physical Google Pixel phone.