### PR TITLE
Directions to Outdoor POIs

### DIFF
--- a/client/__tests__/component_tests/MapContext-test.tsx
+++ b/client/__tests__/component_tests/MapContext-test.tsx
@@ -1,16 +1,65 @@
 import React, { useEffect } from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { render, waitFor, act } from '@testing-library/react-native';
 import { MapProvider, useMap, MapState } from '@/modules/map/MapContext';
 
 // Mock dependencies
-jest.mock('@/modules/map/MapService', () => ({ getRoute: jest.fn() }));
+jest.mock('@rnmapbox/maps', () => ({
+  MapView: 'MapView',
+  Camera: 'Camera',
+}));
+
+jest.mock('@/modules/map/MapService', () => ({
+  getRoute: jest.fn(() =>
+    Promise.resolve({
+      segments: [
+        {
+          coordinates: [
+            [-73.5, 45.5],
+            [-73.6, 45.6],
+          ],
+        },
+      ],
+      duration: 1000,
+      distance: 2000,
+    })
+  ),
+}));
 jest.mock('expo-location', () => ({
   watchPositionAsync: jest.fn(() => Promise.resolve({ remove: jest.fn() })),
+  LocationSubscription: jest.fn(),
 }));
 jest.mock('@/services/CoordinateService', () => ({
   getCurrentCoordinates: jest.fn(() => Promise.resolve([-74.006, 40.7128])),
-  calculateRouteCoordinateBounds: jest.fn(),
+  calculateRouteCoordinateBounds: jest.fn(() => ({
+    ne: [-73.5, 45.6],
+    sw: [-73.6, 45.5],
+  })),
 }));
+
+jest.mock('@/modules/map/IndoorMap', () => ({
+  indoorMaps: [
+    {
+      id: 'map1',
+      name: 'Test Map 1',
+      bounds: [-73.58, 45.49, -73.57, 45.5] as [number, number, number, number],
+      levelsRange: { min: -1, max: 3 },
+    },
+    {
+      id: 'map2',
+      name: 'Test Map 2',
+      bounds: [-73.59, 45.48, -73.58, 45.49] as [number, number, number, number],
+      levelsRange: { min: 0, max: 2 },
+    },
+  ],
+  IndoorMap: jest.fn(),
+}));
+
+jest.mock('@/modules/map/IndoorMapUtils', () => ({
+  bboxCenter: jest.fn((bbox) => [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2]),
+  overlap: jest.fn(() => true),
+}));
+
+jest.mock('@turf/distance', () => jest.fn(() => 0.5));
 
 const TestComponent: React.FC<{ onMapContext?: (ctx: ReturnType<typeof useMap>) => void }> = ({
   onMapContext,
@@ -43,6 +92,116 @@ describe('MapContext', () => {
       zoomLevel: 15,
       state: MapState.Idle,
       startLocation: null,
+      endLocation: null,
+      route: null,
+      indoorMap: null,
     });
+  });
+
+  test('loadRouteFromCoordinates sets route and fits bounds', async () => {
+    let mapContext: ReturnType<typeof useMap> | undefined;
+    const mockFitBounds = jest.fn();
+    const { getRoute } = require('@/modules/map/MapService');
+
+    render(
+      <MapProvider>
+        <TestComponent onMapContext={(ctx) => (mapContext = ctx)} />
+      </MapProvider>
+    );
+
+    await waitFor(() => {
+      expect(mapContext).toBeDefined();
+    });
+
+    if (mapContext) {
+      // @ts-ignore - mocking the ref
+      mapContext.cameraRef.current = {
+        fitBounds: mockFitBounds,
+      };
+    }
+
+    await act(async () => {
+      await mapContext?.loadRouteFromCoordinates([-73.57, 45.5], [-73.58, 45.51], 'walking');
+    });
+
+    expect(getRoute).toHaveBeenCalledWith([-73.57, 45.5], [-73.58, 45.51], 'walking');
+
+    expect(mockFitBounds).toHaveBeenCalledWith([-73.5, 45.6], [-73.6, 45.5], 50, 1500);
+
+    expect(mapContext?.route).toEqual({
+      segments: [
+        {
+          coordinates: [
+            [-73.5, 45.5],
+            [-73.6, 45.6],
+          ],
+        },
+      ],
+      duration: 1000,
+      distance: 2000,
+    });
+  });
+
+  test('updateSelectedMapIfNeeded updates indoor map and level', async () => {
+    let mapContext: ReturnType<typeof useMap> | undefined;
+    const overlap = require('@/modules/map/IndoorMapUtils').overlap;
+    const { indoorMaps } = require('@/modules/map/IndoorMap');
+
+    render(
+      <MapProvider>
+        <TestComponent onMapContext={(ctx) => (mapContext = ctx)} />
+      </MapProvider>
+    );
+
+    await waitFor(() => {
+      expect(mapContext).toBeDefined();
+    });
+
+    if (mapContext) {
+      // @ts-ignore - mocking the map ref
+      mapContext.mapRef.current = {
+        getZoom: jest.fn().mockResolvedValue(18),
+        getVisibleBounds: jest.fn().mockResolvedValue([
+          [-73.57, 45.5],
+          [-73.58, 45.49],
+        ]),
+      };
+    }
+
+    await act(async () => {
+      await mapContext?.updateSelectedMapIfNeeded();
+    });
+
+    await waitFor(() => {
+      expect(mapContext?.indoorMap).toEqual(indoorMaps[0]);
+      expect(mapContext?.level).toBe(indoorMaps[0].levelsRange.min);
+    });
+  });
+
+  test('handles route loading error gracefully', async () => {
+    let mapContext: ReturnType<typeof useMap> | undefined;
+    const { getRoute } = require('@/modules/map/MapService');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    getRoute.mockRejectedValueOnce(new Error('Route not found'));
+
+    render(
+      <MapProvider>
+        <TestComponent onMapContext={(ctx) => (mapContext = ctx)} />
+      </MapProvider>
+    );
+
+    await waitFor(() => {
+      expect(mapContext).toBeDefined();
+    });
+
+    await act(async () => {
+      await mapContext?.loadRouteFromCoordinates([-73.57, 45.5], [-73.58, 45.51]);
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error setting route:', expect.any(Error));
+    expect(mapContext?.route).toBeNull();
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/client/__tests__/component_tests/MapContext-test.tsx
+++ b/client/__tests__/component_tests/MapContext-test.tsx
@@ -144,7 +144,6 @@ describe('MapContext', () => {
 
   test('updateSelectedMapIfNeeded updates indoor map and level', async () => {
     let mapContext: ReturnType<typeof useMap> | undefined;
-    const overlap = require('@/modules/map/IndoorMapUtils').overlap;
     const { indoorMaps } = require('@/modules/map/IndoorMap');
 
     render(

--- a/client/__tests__/component_tests/POIMarker-test.tsx
+++ b/client/__tests__/component_tests/POIMarker-test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import POIMarker from '@/components/POIMarker';
+import { POIType } from '@/modules/map/PointsOfInterestTypes';
+
+interface IoniconsProps {
+  name: string;
+  color: string;
+  size: number;
+}
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: IoniconsProps) => null,
+}));
+
+const mockIconsImpl = jest.fn();
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: { name: string; color: string; size: number }) => {
+    mockIconsImpl(props);
+    return null;
+  },
+}));
+
+describe('POIMarker Component', () => {
+  beforeEach(() => {
+    mockIconsImpl.mockClear();
+  });
+
+  const POI_CONFIG = [
+    { type: 'bixi', icon: 'bicycle-outline', color: '#5cb85c' },
+    { type: 'metro', icon: 'subway-outline', color: '#0d6efd' },
+    { type: 'bus', icon: 'bus-outline', color: '#6f42c1' },
+    { type: 'restaurant', icon: 'restaurant-outline', color: '#fd7e14' },
+    { type: 'park', icon: 'leaf-outline', color: '#20c997' },
+    { type: 'library', icon: 'book-outline', color: '#6c757d' },
+    { type: 'shopping', icon: 'cart-outline', color: '#dc3545' },
+    { type: 'other', icon: 'location-outline', color: '#adb5bd' },
+  ];
+
+  it('renders correctly with snapshot for each POI type', () => {
+    POI_CONFIG.forEach(({ type }) => {
+      const { toJSON } = render(<POIMarker type={type as POIType} />);
+      expect(toJSON()).toMatchSnapshot(`POIMarker with type ${type}`);
+    });
+  });
+
+  it('uses correct icon for each POI type', () => {
+    POI_CONFIG.forEach(({ type, icon }) => {
+      render(<POIMarker type={type as POIType} />);
+
+      expect(mockIconsImpl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: icon,
+          color: 'white',
+          size: expect.any(Number),
+        })
+      );
+
+      mockIconsImpl.mockClear();
+    });
+  });
+
+  it('falls back to location-outline for unknown types', () => {
+    // @ts-ignore - Passing an invalid type to test fallback behavior
+    render(<POIMarker type="invalid" />);
+
+    expect(mockIconsImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'location-outline',
+        color: 'white',
+        size: expect.any(Number),
+      })
+    );
+  });
+
+  it('renders with correct structure', () => {
+    const { toJSON } = render(<POIMarker type="park" />);
+    const result = toJSON();
+
+    expect(result).toHaveProperty('type');
+    expect(result).toHaveProperty('props');
+    expect(result).toHaveProperty('children');
+  });
+});

--- a/client/__tests__/component_tests/__snapshots__/POIMarker-test.tsx.snap
+++ b/client/__tests__/component_tests/__snapshots__/POIMarker-test.tsx.snap
@@ -1,0 +1,233 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type bixi 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#5cb85c",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type bus 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#6f42c1",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type library 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#6c757d",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type metro 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#0d6efd",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type other 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#adb5bd",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type park 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#20c997",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type restaurant 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#fd7e14",
+      },
+    ]
+  }
+/>
+`;
+
+exports[`POIMarker Component renders correctly with snapshot for each POI type: POIMarker with type shopping 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "borderColor": "white",
+        "borderRadius": 18,
+        "borderWidth": 2,
+        "elevation": 5,
+        "height": 36,
+        "justifyContent": "center",
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.25,
+        "shadowRadius": 3.84,
+        "width": 36,
+      },
+      {
+        "backgroundColor": "#dc3545",
+      },
+    ]
+  }
+/>
+`;

--- a/client/app/(tabs)/calendar.tsx
+++ b/client/app/(tabs)/calendar.tsx
@@ -15,7 +15,8 @@ import moment from 'moment';
 import Swiper from 'react-native-swiper';
 import { extractScheduleData, fetchCalendarEvents } from '@/services/GoogleScheduleService';
 import SimpleModal from '@/components/CalendarIdBox';
-import { Coordinates, MapState, useMap, Location } from '@/modules/map/MapContext';
+import { Coordinates, MapState, useMap } from '@/modules/map/MapContext';
+import { Location } from '@/modules/map/Types';
 import { getBuildingCoordinates } from '@/services/BuildingService';
 
 const { width } = Dimensions.get('window');

--- a/client/components/LocationInput.tsx
+++ b/client/components/LocationInput.tsx
@@ -1,4 +1,5 @@
-import { Location, MapState, useMap } from '@/modules/map/MapContext';
+import { MapState, useMap } from '@/modules/map/MapContext';
+import { Location } from '@/modules/map/Types';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useEffect } from 'react';
 import { TextInput, View, StyleSheet, TouchableOpacity, Text } from 'react-native';

--- a/client/modules/map/MapView.tsx
+++ b/client/modules/map/MapView.tsx
@@ -145,23 +145,7 @@ export default function MapView() {
             anchor={{ x: 0.5, y: 0.5 }}>
             <TouchableOpacity
               onPress={() => {
-                const poiLocation: Location = {
-                  name: poi.name,
-                  coordinates: poi.coordinates,
-                  data: {
-                    address: poi.address,
-                    isOpen: poi.openingHours.isOpen,
-                    hours: poi.openingHours.hours,
-                    description: poi.description ?? '',
-                  },
-                };
-
-                setEndLocation(poiLocation);
-                setState(MapState.Information);
-
-                if (cameraRef.current) {
-                  cameraRef.current.flyTo(poi.coordinates, 17);
-                }
+                onMapClick({ geometry: { coordinates: poi.coordinates } });
               }}
               activeOpacity={0.7}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>

--- a/maestro/flows/AT_5.1.yaml
+++ b/maestro/flows/AT_5.1.yaml
@@ -1,0 +1,10 @@
+appId: com.anonymous.client
+---
+- doubleTapOn:
+    point: '50%,50%'
+- doubleTapOn:
+    point: '50%,50%'
+- assertVisible: ''
+- assertVisible: ''
+- assertVisible: ''
+- tapOn: ''

--- a/maestro/flows/AT_5.2.yaml
+++ b/maestro/flows/AT_5.2.yaml
@@ -1,0 +1,13 @@
+appId: com.anonymous.client
+---
+- doubleTapOn:
+    point: '50%,50%'
+- doubleTapOn:
+    point: '50%,50%'
+- assertVisible: ''
+- assertVisible: ''
+- assertVisible: ''
+- tapOn: ''
+- tapOn: ' Directions'
+- tapOn: ' 2 min'
+- tapOn: ''


### PR DESCRIPTION
### In this PR:

  * Users can tap on an outdoor Point of Interest, and the information panel will pop up.
  * Users can then tap on the "Directions" button and the start location will be automatically inputted as the Point of Interest.

Notes:

  * The implementation for US 5.2 was completed in the same branch as US 5.1, which is [found here](https://github.com/mahutt/ViniMap/issues/67).

![image](https://github.com/user-attachments/assets/261c276f-1220-4bbc-bec7-34ca00958b0a)
