### PR TITLE
Remove accidental package-lock from root directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "ViniMap",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
2 weeks ago, during the pre-mature PR merge debacle, I accidentally committed a package-lock.json file to the root directory (in which there should not be any such file). This PR is to remove the file.