### PR TITLE
Fix code smells (resolve technical debt)

### DIFF
--- a/client/components/LocationsAutocomplete.tsx
+++ b/client/components/LocationsAutocomplete.tsx
@@ -33,9 +33,9 @@ export default function LocationsAutocomplete({
 
   return (
     <View style={styles.locationsContainer}>
-      {locations.map((location, index) => (
+      {locations.map((location) => (
         <View
-          key={`location-${index}`}
+          key={`${location.name}-${location.coordinates[0]}-${location.coordinates[1]}`}
           style={styles.locationItem}
           onTouchEnd={() => {
             callback(location);

--- a/client/components/ui/IconSymbol.ios.tsx
+++ b/client/components/ui/IconSymbol.ios.tsx
@@ -7,13 +7,13 @@ export function IconSymbol({
   color,
   style,
   weight = 'regular',
-}: {
+}: Readonly<{
   name: SymbolViewProps['name'];
   size?: number;
   color: string;
   style?: StyleProp<ViewStyle>;
   weight?: SymbolWeight;
-}) {
+}>) {
   return (
     <SymbolView
       weight={weight}

--- a/client/components/ui/IconSymbol.tsx
+++ b/client/components/ui/IconSymbol.tsx
@@ -1,7 +1,6 @@
 // This file is a fallback for using MaterialIcons on Android and web.
 
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { SymbolWeight } from 'expo-symbols';
 import React from 'react';
 import { OpaqueColorValue, StyleProp, TextStyle } from 'react-native';
 
@@ -30,12 +29,11 @@ export function IconSymbol({
   size = 24,
   color,
   style,
-}: {
+}: Readonly<{
   name: IconSymbolName;
   size?: number;
   color: string | OpaqueColorValue;
   style?: StyleProp<TextStyle>;
-  weight?: SymbolWeight;
-}) {
+}>) {
   return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;
 }


### PR DESCRIPTION
Over the past few sprints, we've been at a consistent 20 minutes of "technical debt" as reported by SonarQube (due to 4 code smells). This PR resolves those code smells and aims to reduce our technical debt to 0 minutes.

![Code Quality Risks by Sprint-2](https://github.com/user-attachments/assets/4cde5b02-e326-4620-b7e3-1bd78772f4f2)

Since this PR includes changes to both `client/components/ui/IconSymbol.tsx` and `client/components/ui/IconSymbol.ios.tsx`, it is necessary that both someone on MacOS and someone on Windows review and test this PR.

Assuming we continue to be disciplined with our PR SonarQube reports, I'm confident we can easily maintain 0 minutes of technical debt all the way through release 3!