### PR TITLE
Fix Button Touch Areas

### DIFF
--- a/client/__tests__/component_tests/CenterLocationButton-test.tsx
+++ b/client/__tests__/component_tests/CenterLocationButton-test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import CenterLocationComponent from '@/components/ui/IconCenterLocation';
+import CenterLocationComponent from '@/components/ui/CenterLocationButton';
 import { useMap } from '@/modules/map/MapContext';
 
 jest.mock('@/services/CoordinateService', () => ({

--- a/client/__tests__/component_tests/HomeScreen-test.tsx
+++ b/client/__tests__/component_tests/HomeScreen-test.tsx
@@ -32,7 +32,7 @@ jest.mock('@/components/SearchBar', () => ({
 
 jest.mock('@/modules/map/MapView', () => createMockComponent('MapView'));
 jest.mock('@/modules/map/PitchButton', () => createMockComponent('PitchButton'));
-jest.mock('@/components/ui/IconCenterLocation', () =>
+jest.mock('@/components/ui/CenterLocationButton', () =>
   createMockComponent('CenterLocationComponent')
 );
 jest.mock('@/components/LocationInfo', () => ({

--- a/client/__tests__/component_tests/__snapshots__/PitchButton-test.tsx.snap
+++ b/client/__tests__/component_tests/__snapshots__/PitchButton-test.tsx.snap
@@ -2,6 +2,33 @@
 
 exports[`PitchButton renders correctly 1`] = `
 <View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
     {
       "alignItems": "center",
@@ -18,45 +45,10 @@ exports[`PitchButton renders correctly 1`] = `
     }
   }
 >
-  <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": undefined,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
-    accessible={true}
-    collapsable={false}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      {
-        "opacity": 1,
-      }
-    }
-  >
-    <MockedMaterialCommunityIcons
-      color="white"
-      name="angle-obtuse"
-      size={35}
-    />
-  </View>
+  <MockedMaterialCommunityIcons
+    color="white"
+    name="angle-obtuse"
+    size={35}
+  />
 </View>
 `;

--- a/client/app/(tabs)/calendar.tsx
+++ b/client/app/(tabs)/calendar.tsx
@@ -118,11 +118,9 @@ export default function Calendar() {
       <View style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.title}>Your Schedule</Text>
-          <View style={styles.uploadButton}>
-            <TouchableOpacity onPress={buttonPress}>
-              <Text style={styles.uploadButtonText}>Upload</Text>
-            </TouchableOpacity>
-          </View>
+          <TouchableOpacity style={styles.uploadButton} onPress={buttonPress}>
+            <Text style={styles.uploadButtonText}>Upload</Text>
+          </TouchableOpacity>
         </View>
 
         <View style={styles.picker}>

--- a/client/app/(tabs)/index.tsx
+++ b/client/app/(tabs)/index.tsx
@@ -9,8 +9,7 @@ import PitchButton from '@/modules/map/PitchButton';
 
 import { useMap, MapState } from '@/modules/map/MapContext';
 
-import CenterLocationComponent from '@/components/ui/IconCenterLocation';
-
+import CenterLocationButton from '@/components/ui/CenterLocationButton';
 import { LocationInfo } from '@/components/LocationInfo';
 import { RoutePlanner } from '@/components/RoutePlanner';
 import ToggleCampusButton from '@/components/ui/ToggleCampusButton';
@@ -30,7 +29,7 @@ export default function HomeScreen() {
           <ToggleCampusButton />
         </>
       )}
-      {state === MapState.Idle && <CenterLocationComponent />}
+      {state === MapState.Idle && <CenterLocationButton />}
       {state === MapState.Information && <LocationInfo />}
       {state === MapState.RoutePlanning && <RoutePlanner />}
       <MapHint />

--- a/client/components/ui/CenterLocationButton.tsx
+++ b/client/components/ui/CenterLocationButton.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
-import { TouchableOpacity, View, StyleSheet } from 'react-native';
+import { TouchableOpacity, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useMap } from '@/modules/map/MapContext';
 
-const CenterLocationComponent = () => {
+const CenterLocationButton = () => {
   const { flyTo, userLocation } = useMap();
 
   const handlePress = useCallback(() => {
@@ -15,16 +15,14 @@ const CenterLocationComponent = () => {
   }, [userLocation, flyTo]);
 
   return (
-    <View style={styles.container}>
-      <TouchableOpacity testID="center-location-button" style={styles.button} onPress={handlePress}>
-        <Ionicons name="locate" size={24} color="white" />
-      </TouchableOpacity>
-    </View>
+    <TouchableOpacity testID="center-location-button" style={styles.button} onPress={handlePress}>
+      <Ionicons name="locate" size={24} color="white" />
+    </TouchableOpacity>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
+  button: {
     position: 'absolute',
     bottom: 100,
     right: 36,
@@ -36,10 +34,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  button: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
 });
 
-export default CenterLocationComponent;
+export default CenterLocationButton;

--- a/client/modules/map/PitchButton.tsx
+++ b/client/modules/map/PitchButton.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View, TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 import React from 'react';
 import { useMap } from './MapContext';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
@@ -15,11 +15,9 @@ export default function PitchButton() {
     setPitchLevel(newPitch);
   };
   return (
-    <View style={styles.pitchButtonContainer}>
-      <TouchableOpacity onPress={pressHandler}>
-        <MaterialCommunityIcons name="angle-obtuse" size={35} color="white" />
-      </TouchableOpacity>
-    </View>
+    <TouchableOpacity style={styles.pitchButtonContainer} onPress={pressHandler}>
+      <MaterialCommunityIcons name="angle-obtuse" size={35} color="white" />
+    </TouchableOpacity>
   );
 }
 


### PR DESCRIPTION
This PR fixes 3 buttons whose "hitboxes" were areas within the actual (apparent) button, instead of the (apparent) button itself. This means that buttons wouldn't response to taps near the edges of the button. The following buttons are adjusted:
- `CenterLocationButton` (renamed from `CenterLocationComponent`)
- `PitchButton`
- Upload button in calendar page

When reviewing this PR, please test all 3 of the buttons above. Try to tap the boundaries of each button and verify that the button is still responsive.