### PR TITLE
Add maestro YAML for AT 4.5

### DIFF
--- a/maestro/flows/AT_4.5.yaml
+++ b/maestro/flows/AT_4.5.yaml
@@ -1,0 +1,10 @@
+appId: com.anonymous.client
+---
+- doubleTapOn:
+    point: '50%,50%'
+- doubleTapOn:
+    point: '50%,50%'
+- doubleTapOn:
+    point: '50%,50%'
+- tapOn:
+    point: '56%,61%'


### PR DESCRIPTION
This PR introduces the maestro acceptance test YAML file. I originally intended to commit this in the [PR for indoor points of interest](https://github.com/mahutt/ViniMap/pull/190).