### PR TITLE
Adding the Task icon for Android

### DIFF
--- a/client/components/ui/IconSymbol.tsx
+++ b/client/components/ui/IconSymbol.tsx
@@ -10,6 +10,8 @@ const MAPPING = {
   gear: 'settings',
   'chevron.up': 'keyboard-arrow-up',
   'chevron.down': 'keyboard-arrow-down',
+  checklist: 'assignment', //tasks tab
+  xmark: 'close', //used in TaskCard
 } as Partial<
   Record<
     import('expo-symbols').SymbolViewProps['name'],


### PR DESCRIPTION
Previously, the icon would not show for Android emulators. This PR addresses the problem. See the screenshot below for a visualization of the new icon.

![image](https://github.com/user-attachments/assets/a8041481-2fc7-4781-bf2f-08590bad8fce)
