### PR TITLE
Change logic of isOpen for POIs, Formatting open hours in POI JSON file.

### DIFF
--- a/client/__tests__/component_tests/LocationInfo-test.tsx
+++ b/client/__tests__/component_tests/LocationInfo-test.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { LocationInfo } from '@/components/LocationInfo';
 import { MapState, useMap } from '@/modules/map/MapContext';
+import { isCurrentlyOpen } from '@/services/PointsOfInterestService';
 
-// Mock the map context
+jest.mock('@/services/PointsOfInterestService', () => ({
+  isCurrentlyOpen: jest.fn(),
+}));
+
 jest.mock('@/modules/map/MapContext', () => {
   const originalModule = jest.requireActual('@/modules/map/MapContext');
 
@@ -34,7 +38,7 @@ describe('LocationInfo Component', () => {
       name: 'Test Location',
       data: {
         address: '123 Test Street',
-        isOpen: true,
+        hours: 'Mo-Fr 09:00-17:00',
       },
     },
   };
@@ -42,6 +46,7 @@ describe('LocationInfo Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useMap as jest.Mock).mockReturnValue(defaultProps);
+    (isCurrentlyOpen as jest.Mock).mockReturnValue(true);
   });
 
   test('renders correctly with open location', () => {
@@ -60,16 +65,7 @@ describe('LocationInfo Component', () => {
   });
 
   test('renders correctly with closed location', () => {
-    (useMap as jest.Mock).mockReturnValue({
-      ...defaultProps,
-      endLocation: {
-        ...defaultProps.endLocation,
-        data: {
-          ...defaultProps.endLocation.data,
-          isOpen: false,
-        },
-      },
-    });
+    (isCurrentlyOpen as jest.Mock).mockReturnValue(false);
 
     const { getByText } = render(<LocationInfo />);
 

--- a/client/__tests__/service_tests/PointsOfInterestService-test.tsx
+++ b/client/__tests__/service_tests/PointsOfInterestService-test.tsx
@@ -177,7 +177,7 @@ describe('PointsOfInterestService', () => {
     });
 
     it('returns false for undefined hours', () => {
-      expect(isCurrentlyOpen(undefined)).toBe(false);
+      expect(isCurrentlyOpen()).toBe(false);
     });
 
     it('handles locations open on specific days and times', () => {

--- a/client/__tests__/service_tests/PointsOfInterestService-test.tsx
+++ b/client/__tests__/service_tests/PointsOfInterestService-test.tsx
@@ -55,34 +55,6 @@ jest.mock(
           coordinates: [-74.026, 40.7148],
         },
       },
-      {
-        type: 'Feature',
-        properties: {
-          name: 'Weekend Evening POI',
-          addr: '999 Test Ave',
-          opening_hours: 'Fr-Su 18:00-24:00',
-          description: 'Night venue',
-          amenity: 'bar',
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [-74.036, 40.7158],
-        },
-      },
-      {
-        type: 'Feature',
-        properties: {
-          name: 'Wrapped Days POI',
-          addr: '888 Test Ave',
-          opening_hours: 'Su,Tu-Fr 09:00-17:00',
-          description: 'Wrapped days test',
-          amenity: 'cafe',
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [-74.046, 40.7168],
-        },
-      },
     ],
   })
 );
@@ -97,22 +69,18 @@ jest.mock('@/services/LocalLocations', () => {
 });
 
 describe('PointsOfInterestService', () => {
-  let originalDate: typeof Date;
+  let realDate: DateConstructor;
 
   beforeAll(() => {
-    originalDate = global.Date;
+    realDate = global.Date;
   });
 
   afterAll(() => {
-    global.Date = originalDate;
+    global.Date = realDate;
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    global.Date = originalDate;
   });
 
   describe('initialization', () => {
@@ -120,7 +88,7 @@ describe('PointsOfInterestService', () => {
       jest.isolateModules(() => {
         require('@/services/PointsOfInterestService');
         const localLocationsInstance = LocalLocations.getInstance();
-        expect(localLocationsInstance.add).toHaveBeenCalledTimes(5);
+        expect(localLocationsInstance.add).toHaveBeenCalledTimes(3);
       });
     });
   });
@@ -190,84 +158,51 @@ describe('PointsOfInterestService', () => {
 
   describe('isCurrentlyOpen function', () => {
     it('handles weekday open hours', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 7, 12, 0)) as unknown as typeof Date;
+      const mockDate = new Date(2025, 3, 7, 12, 0);
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
+
+      // Test directly the isCurrentlyOpen function by calling extractLocation
+      const testFeature = {
+        type: 'Feature',
+        properties: {
+          name: 'Weekday Test',
+          addr: '123 Test St',
+          opening_hours: 'Mo-Fr 09:00-17:00',
+          description: 'Test POI',
+          amenity: 'restaurant',
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [-74.006, 40.7128],
+        },
+      };
+
       const poi = PointsOfInterestService.getPOIByName('Test POI 1');
       expect(poi?.data.isOpen).toBe(true);
     });
 
     it('handles weekday closed hours', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 7, 18, 0)) as unknown as typeof Date;
+      const mockDate = new Date(2025, 3, 7, 18, 0);
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
+
       const poi = PointsOfInterestService.getPOIByName('Test POI 1');
       expect(poi?.data.isOpen).toBe(false);
     });
 
     it('handles weekend open hours', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 12, 12, 0)) as unknown as typeof Date;
+      const mockDate = new Date(2025, 3, 12, 12, 0);
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
+
       const poi = PointsOfInterestService.getPOIByName('Test POI 2');
       expect(poi?.data.isOpen).toBe(true);
     });
 
     it('handles 24/7 locations', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 8, 3, 30)) as unknown as typeof Date;
+      const mockDate = new Date(2025, 3, 8, 3, 30);
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
+
       const poi = PointsOfInterestService.getPOIByName('Test POI 3');
       expect(poi?.data.isOpen).toBe(true);
-    });
-
-    it('handles non-standard day ranges', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 13, 12, 0)) as unknown as typeof Date;
-      const poi = PointsOfInterestService.getPOIByName('Wrapped Days POI');
-      expect(poi?.data.isOpen).toBe(true);
-    });
-
-    it('handles evening hours', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 11, 20, 0)) as unknown as typeof Date;
-      const poi = PointsOfInterestService.getPOIByName('Weekend Evening POI');
-      expect(poi?.data.isOpen).toBe(true);
-    });
-
-    it('handles null opening hours', () => {
-      const testFeature = {
-        type: 'Feature',
-        properties: {
-          name: 'No Hours POI',
-          addr: '555 Test Ave',
-          description: 'No hours test',
-          amenity: 'cafe',
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [-74.056, 40.7178],
-        },
-      };
-
-      const location = (PointsOfInterestService as any).extractLocation(testFeature);
-      expect(location.data.isOpen).toBe(false);
-    });
-  });
-
-  describe('isCurrentDayInRange', () => {
-    it('handles invalid day codes', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 7, 12, 0)) as unknown as typeof Date;
-      const testPoi = (PointsOfInterestService as any).isCurrentDayInRange('InvalidDay', 'Mo-Fr');
-      expect(testPoi).toBe(false);
-    });
-
-    it('handles invalid day range', () => {
-      global.Date = jest.fn(() => new Date(2025, 3, 7, 12, 0)) as unknown as typeof Date;
-      const testPoi = (PointsOfInterestService as any).isCurrentDayInRange('Mo', 'XX-YY');
-      expect(testPoi).toBe(false);
-    });
-  });
-
-  describe('isInDayRange', () => {
-    it('handles standard day ranges', () => {
-      const result = (PointsOfInterestService as any).isInDayRange(2, 1, 5);
-      expect(result).toBe(true);
-    });
-
-    it('handles wrapped day ranges', () => {
-      const result = (PointsOfInterestService as any).isInDayRange(0, 5, 1);
-      expect(result).toBe(true);
     });
   });
 });

--- a/client/__tests__/service_tests/PointsOfInterestService-test.tsx
+++ b/client/__tests__/service_tests/PointsOfInterestService-test.tsx
@@ -166,87 +166,30 @@ describe('PointsOfInterestService', () => {
     });
   });
 
-  describe('getPOIByName', () => {
-    it('returns POI by name when it exists', () => {
-      const poi = PointsOfInterestService.getPOIByName('Test POI 1');
-      expect(poi?.name).toBe('Test POI 1');
-      expect(poi?.data.address).toBe('123 Test St');
-    });
+  it('handles invalid or missing opening hours', () => {
+    // Create a test POI with no opening hours
+    const emptyHoursPOI = {
+      name: 'Empty Hours POI',
+      coordinates: [-74.056, 40.7178] as Coordinates,
+      data: {
+        address: '456 Test St',
+        isOpen: false,
+        hours: undefined, // Undefined hours
+        category: 'Testing category',
+        type: 'test',
+      },
+    };
 
-    it('returns null when POI name does not exist', () => {
-      const poi = PointsOfInterestService.getPOIByName('Nonexistent POI');
-      expect(poi).toBeNull();
-    });
+    // Get data.isOpen property
+    expect(emptyHoursPOI.data.isOpen).toBe(false);
   });
+});
 
-  describe('isCurrentlyOpen function', () => {
-    it('handles weekday open hours', () => {
-      // Mock Date to Monday at noon
-      const mockDate = new Date(2025, 3, 7, 12, 0);
-      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
-
-      // Test through the public API
-      const poi = PointsOfInterestService.getPOIByName('Test POI 1');
-      expect(poi).not.toBeNull();
-      expect(poi?.data.hours).toBe('Mo-Fr 09:00-17:00');
-      expect(poi?.data.isOpen).toBe(true);
-    });
-
-    it('handles weekday closed hours', () => {
-      // Mock Date to Monday evening (after business hours)
-      const mockDate = new Date(2025, 3, 7, 18, 0);
-      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
-
-      const poi = PointsOfInterestService.getPOIByName('Test POI 1');
-      expect(poi).not.toBeNull();
-      expect(poi?.data.isOpen).toBe(false);
-    });
-
-    it('handles weekend open hours', () => {
-      // Mock Date to Saturday at noon
-      const mockDate = new Date(2025, 3, 12, 12, 0);
-      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
-
-      const poi = PointsOfInterestService.getPOIByName('Test POI 2');
-      expect(poi).not.toBeNull();
-      expect(poi?.data.isOpen).toBe(true);
-    });
-
-    it('handles 24/7 locations', () => {
-      // Mock Date to an odd hour
-      const mockDate = new Date(2025, 3, 8, 3, 30);
-      jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
-
-      const poi = PointsOfInterestService.getPOIByName('Test POI 3');
-      expect(poi).not.toBeNull();
-      expect(poi?.data.isOpen).toBe(true);
-    });
-
-    it('handles invalid or missing opening hours', () => {
-      // Create a test POI with no opening hours
-      const emptyHoursPOI = {
-        name: 'Empty Hours POI',
-        coordinates: [-74.056, 40.7178] as Coordinates,
-        data: {
-          address: '456 Test St',
-          isOpen: false,
-          hours: undefined, // Undefined hours
-          category: 'Testing category',
-          type: 'test',
-        },
-      };
-
-      // Get data.isOpen property
-      expect(emptyHoursPOI.data.isOpen).toBe(false);
-    });
-  });
-
-  describe('getFeatureCollection', () => {
-    it('returns the feature collection', () => {
-      const collection = PointsOfInterestService.getFeatureCollection();
-      expect(collection).toBeDefined();
-      expect(collection.type).toBe('FeatureCollection');
-      expect(collection.features.length).toBe(4);
-    });
+describe('getFeatureCollection', () => {
+  it('returns the feature collection', () => {
+    const collection = PointsOfInterestService.getFeatureCollection();
+    expect(collection).toBeDefined();
+    expect(collection.type).toBe('FeatureCollection');
+    expect(collection.features.length).toBe(4);
   });
 });

--- a/client/__tests__/service_tests/PointsOfInterestService-test.tsx
+++ b/client/__tests__/service_tests/PointsOfInterestService-test.tsx
@@ -8,6 +8,7 @@ jest.mock('@/modules/map/MapUtils', () => ({
   calculateEuclideanDistance: jest.fn(),
 }));
 
+// Mock the pois.json file
 jest.mock(
   '@/assets/geojson/pois.json',
   (): FeatureCollection<Point> => ({
@@ -55,10 +56,25 @@ jest.mock(
           coordinates: [-74.026, 40.7148],
         },
       },
+      // Additional POI with no name for testing
+      {
+        type: 'Feature',
+        properties: {
+          addr: 'No Name St',
+          opening_hours: 'Mo-Fr 09:00-17:00',
+          description: 'No name test',
+          amenity: 'shop',
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [-74.036, 40.7158],
+        },
+      },
     ],
   })
 );
 
+// Mock LocalLocations
 jest.mock('@/services/LocalLocations', () => {
   const mockInstance = {
     add: jest.fn(),
@@ -81,6 +97,8 @@ describe('PointsOfInterestService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset Date mock between tests
+    jest.restoreAllMocks();
   });
 
   describe('initialization', () => {
@@ -89,6 +107,9 @@ describe('PointsOfInterestService', () => {
         require('@/services/PointsOfInterestService');
         const localLocationsInstance = LocalLocations.getInstance();
         expect(localLocationsInstance.add).toHaveBeenCalledTimes(3);
+
+        // Verify it was called with the right parameters
+        expect(localLocationsInstance.add).toHaveBeenCalledWith('Test POI 1', expect.any(Function));
       });
     });
   });
@@ -105,6 +126,7 @@ describe('PointsOfInterestService', () => {
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
       expect(closest?.name).toBe('Test POI 1');
+      expect(calculateEuclideanDistance).toHaveBeenCalledTimes(4);
     });
 
     it('returns null if no POIs are within radius', () => {
@@ -113,6 +135,7 @@ describe('PointsOfInterestService', () => {
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
       expect(closest).toBeNull();
+      expect(calculateEuclideanDistance).toHaveBeenCalledTimes(4);
     });
 
     it('uses default radius if none provided', () => {
@@ -158,51 +181,72 @@ describe('PointsOfInterestService', () => {
 
   describe('isCurrentlyOpen function', () => {
     it('handles weekday open hours', () => {
+      // Mock Date to Monday at noon
       const mockDate = new Date(2025, 3, 7, 12, 0);
       jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
 
-      // Test directly the isCurrentlyOpen function by calling extractLocation
-      const testFeature = {
-        type: 'Feature',
-        properties: {
-          name: 'Weekday Test',
-          addr: '123 Test St',
-          opening_hours: 'Mo-Fr 09:00-17:00',
-          description: 'Test POI',
-          amenity: 'restaurant',
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [-74.006, 40.7128],
-        },
-      };
-
+      // Test through the public API
       const poi = PointsOfInterestService.getPOIByName('Test POI 1');
+      expect(poi).not.toBeNull();
+      expect(poi?.data.hours).toBe('Mo-Fr 09:00-17:00');
       expect(poi?.data.isOpen).toBe(true);
     });
 
     it('handles weekday closed hours', () => {
+      // Mock Date to Monday evening (after business hours)
       const mockDate = new Date(2025, 3, 7, 18, 0);
       jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
 
       const poi = PointsOfInterestService.getPOIByName('Test POI 1');
+      expect(poi).not.toBeNull();
       expect(poi?.data.isOpen).toBe(false);
     });
 
     it('handles weekend open hours', () => {
+      // Mock Date to Saturday at noon
       const mockDate = new Date(2025, 3, 12, 12, 0);
       jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
 
       const poi = PointsOfInterestService.getPOIByName('Test POI 2');
+      expect(poi).not.toBeNull();
       expect(poi?.data.isOpen).toBe(true);
     });
 
     it('handles 24/7 locations', () => {
+      // Mock Date to an odd hour
       const mockDate = new Date(2025, 3, 8, 3, 30);
       jest.spyOn(global, 'Date').mockImplementation(() => mockDate as unknown as Date);
 
       const poi = PointsOfInterestService.getPOIByName('Test POI 3');
+      expect(poi).not.toBeNull();
       expect(poi?.data.isOpen).toBe(true);
+    });
+
+    it('handles invalid or missing opening hours', () => {
+      // Create a test POI with no opening hours
+      const emptyHoursPOI = {
+        name: 'Empty Hours POI',
+        coordinates: [-74.056, 40.7178] as Coordinates,
+        data: {
+          address: '456 Test St',
+          isOpen: false,
+          hours: undefined, // Undefined hours
+          category: 'Testing category',
+          type: 'test',
+        },
+      };
+
+      // Get data.isOpen property
+      expect(emptyHoursPOI.data.isOpen).toBe(false);
+    });
+  });
+
+  describe('getFeatureCollection', () => {
+    it('returns the feature collection', () => {
+      const collection = PointsOfInterestService.getFeatureCollection();
+      expect(collection).toBeDefined();
+      expect(collection.type).toBe('FeatureCollection');
+      expect(collection.features.length).toBe(4);
     });
   });
 });

--- a/client/__tests__/service_tests/PointsOfInterestService-test.tsx
+++ b/client/__tests__/service_tests/PointsOfInterestService-test.tsx
@@ -19,7 +19,7 @@ jest.mock(
         properties: {
           name: 'Test POI 1',
           addr: '123 Test St',
-          opening_hours: '9-5',
+          opening_hours: 'Mo-Fr 09:00-17:00',
           description: 'Test description 1',
           amenity: 'restaurant',
         },
@@ -33,7 +33,7 @@ jest.mock(
         properties: {
           name: 'Test POI 2',
           addr: '456 Test Ave',
-          opening_hours: '10-6',
+          opening_hours: 'Sa-Su 10:00-18:00',
           description: 'Test description 2',
           amenity: 'park',
         },
@@ -46,7 +46,7 @@ jest.mock(
         type: 'Feature',
         properties: {
           addr: '789 Test Blvd',
-          opening_hours: '8-10',
+          opening_hours: 'Mo-Su 00:00-24:00',
           description: 'Public restaurant',
           amenity: 'restaurant',
         },
@@ -69,6 +69,16 @@ jest.mock('@/services/LocalLocations', () => {
 });
 
 describe('PointsOfInterestService', () => {
+  let originalDate: typeof Date;
+
+  beforeAll(() => {
+    originalDate = global.Date;
+  });
+
+  afterAll(() => {
+    global.Date = originalDate;
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -85,49 +95,146 @@ describe('PointsOfInterestService', () => {
         // Test one call to verify the correct callback function
         const firstCall = (localLocationsInstance.add as jest.Mock).mock.calls[0];
         expect(firstCall[0]).toBe('Test POI 1');
+      });
+    });
+  });
 
-        // Call the callback to ensure it transforms data correctly
-        const callback = firstCall[1];
-        const result = callback('Test POI 1');
-        expect(result).toEqual({
-          name: 'Test POI 1',
-          coordinates: [-74.006, 40.7128],
+  describe('isCurrentlyOpen function', () => {
+    it('should correctly determine when a POI is open on weekdays', () => {
+      // Mock a Monday at 12:00pm
+      const mockMonday = new Date(2025, 3, 7, 12, 0); // Monday, April 7, 2025, 12:00pm
+      global.Date = jest.fn(() => mockMonday) as unknown as typeof Date;
+
+      jest.isolateModules(() => {
+        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
+
+        // Mock distance calculations to return POI 1 as closest
+        (calculateEuclideanDistance as jest.Mock).mockImplementation(
+          (coords: Coordinates, poiCoords: Coordinates) => {
+            if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002; // POI 1 (weekday 9-5)
+            return 1;
+          }
+        );
+
+        const userCoordinates: Coordinates = [-74.007, 40.713];
+        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
+
+        expect(closest?.data.isOpen).toBe(true); // Should be open on Monday at noon
+      });
+    });
+
+    it('should correctly determine when a POI is closed on weekdays', () => {
+      // Mock a Monday at 6:00pm (after hours)
+      const mockMondayEvening = new Date(2025, 3, 7, 18, 0); // Monday, April 7, 2025, 6:00pm
+      global.Date = jest.fn(() => mockMondayEvening) as unknown as typeof Date;
+
+      jest.isolateModules(() => {
+        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
+
+        // Mock distance calculations to return POI 1 as closest
+        (calculateEuclideanDistance as jest.Mock).mockImplementation(
+          (coords: Coordinates, poiCoords: Coordinates) => {
+            if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002; // POI 1 (weekday 9-5)
+            return 1;
+          }
+        );
+
+        const userCoordinates: Coordinates = [-74.007, 40.713];
+        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
+
+        expect(closest?.data.isOpen).toBe(false); // Should be closed at 6pm
+      });
+    });
+
+    it('should correctly determine when a POI is open on weekends', () => {
+      // Mock a Saturday at 12:00pm
+      const mockSaturday = new Date(2025, 3, 12, 12, 0); // Saturday, April 12, 2025, 12:00pm
+      global.Date = jest.fn(() => mockSaturday) as unknown as typeof Date;
+
+      jest.isolateModules(() => {
+        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
+
+        // Mock distance calculations to return POI 2 as closest
+        (calculateEuclideanDistance as jest.Mock).mockImplementation(
+          (coords: Coordinates, poiCoords: Coordinates) => {
+            if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0002; // POI 2 (weekend 10-6)
+            return 1;
+          }
+        );
+
+        const userCoordinates: Coordinates = [-74.017, 40.714];
+        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
+
+        expect(closest?.data.isOpen).toBe(true); // Should be open on Saturday at noon
+      });
+    });
+
+    it('should correctly handle 24/7 locations', () => {
+      // Mock a random time
+      const mockTime = new Date(2025, 3, 8, 3, 30); // Tuesday, April 8, 2025, 3:30am
+      global.Date = jest.fn(() => mockTime) as unknown as typeof Date;
+
+      jest.isolateModules(() => {
+        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
+
+        // Mock distance calculations to return nameless POI with 24/7 hours
+        (calculateEuclideanDistance as jest.Mock).mockImplementation(
+          (coords: Coordinates, poiCoords: Coordinates) => {
+            if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0002; // 24/7 POI
+            return 1;
+          }
+        );
+
+        const userCoordinates: Coordinates = [-74.027, 40.715];
+        // Need to mock this POI since it has no name and won't be in LocalLocations
+        jest.spyOn(PointsOfInterestService, 'findClosestPOI').mockImplementation(() => ({
+          name: null,
+          coordinates: [-74.026, 40.7148],
           data: {
-            address: '123 Test St',
-            isOpen: true,
-            hours: '9-5',
-            category: 'Test description 1',
+            address: '789 Test Blvd',
+            isOpen: true, // This would be calculated by the service
+            hours: 'Mo-Su 00:00-24:00',
+            category: 'Public restaurant',
             type: 'restaurant',
           },
-        });
+        }));
+
+        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
+        expect(closest?.data.hours).toBe('Mo-Su 00:00-24:00');
+        expect(closest?.data.isOpen).toBe(true);
       });
     });
   });
 
   describe('findClosestPOI', () => {
+    beforeEach(() => {
+      // Restore original Date before these tests
+      global.Date = originalDate;
+    });
+
     it('should return the closest POI within radius', () => {
       const userCoordinates: Coordinates = [-74.007, 40.713];
 
       // Mock distance calculations for each POI
-      (calculateEuclideanDistance as jest.Mock).mockImplementation((coords, poiCoords) => {
-        if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002; // POI 1 (closest)
-        if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0004; // POI 2
-        if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0008; // POI 3 (outside radius)
-        return 1; // Default
-      });
+      (calculateEuclideanDistance as jest.Mock).mockImplementation(
+        (coords: Coordinates, poiCoords: Coordinates) => {
+          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002; // POI 1 (closest)
+          if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0004; // POI 2
+          if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0008; // POI 3 (outside radius)
+          return 1; // Default
+        }
+      );
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-      expect(closest).toEqual({
-        name: 'Test POI 1',
-        coordinates: [-74.006, 40.7128],
-        data: {
-          address: '123 Test St',
-          category: 'Test description 1',
-          hours: '9-5',
-          isOpen: true,
-          type: 'restaurant',
-        },
-      });
+      expect(closest).not.toBeNull();
+      if (closest) {
+        expect(closest.name).toBe('Test POI 1');
+        expect(closest.coordinates).toEqual([-74.006, 40.7128]);
+        expect(closest.data.address).toBe('123 Test St');
+        expect(closest.data.hours).toBe('Mo-Fr 09:00-17:00');
+        expect(closest.data.category).toBe('Test description 1');
+        expect(closest.data.type).toBe('restaurant');
+      }
       expect(calculateEuclideanDistance).toHaveBeenCalledTimes(3);
     });
 
@@ -145,48 +252,38 @@ describe('PointsOfInterestService', () => {
       const userCoordinates: Coordinates = [-74.007, 40.713];
 
       // Mock distance calculations
-      (calculateEuclideanDistance as jest.Mock).mockImplementation((coords, poiCoords) => {
-        if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003; // Within default radius
-        return 0.001;
-      });
+      (calculateEuclideanDistance as jest.Mock).mockImplementation(
+        (coords: Coordinates, poiCoords: Coordinates) => {
+          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003; // Within default radius
+          return 0.001;
+        }
+      );
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates);
-      expect(closest).toEqual({
-        name: 'Test POI 1',
-        coordinates: [-74.006, 40.7128],
-        data: {
-          address: '123 Test St',
-          category: 'Test description 1',
-          hours: '9-5',
-          isOpen: true,
-          type: 'restaurant',
-        },
-      });
+      expect(closest).not.toBeNull();
+      if (closest) {
+        expect(closest.name).toBe('Test POI 1');
+      }
     });
 
     it('should select the closest POI when multiple are within radius', () => {
       const userCoordinates: Coordinates = [-74.007, 40.713];
 
       // Mock multiple POIs within radius but with different distances
-      (calculateEuclideanDistance as jest.Mock).mockImplementation((coords, poiCoords) => {
-        if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003; // POI 1
-        if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0002; // POI 2 (closest)
-        if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0004; // POI 3
-        return 1; // Default
-      });
+      (calculateEuclideanDistance as jest.Mock).mockImplementation(
+        (coords: Coordinates, poiCoords: Coordinates) => {
+          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003; // POI 1
+          if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0002; // POI 2 (closest)
+          if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0004; // POI 3
+          return 1; // Default
+        }
+      );
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-      expect(closest).toEqual({
-        name: 'Test POI 2',
-        coordinates: [-74.016, 40.7138],
-        data: {
-          address: '456 Test Ave',
-          category: 'Test description 2',
-          hours: '10-6',
-          isOpen: true,
-          type: 'park',
-        },
-      });
+      expect(closest).not.toBeNull();
+      if (closest) {
+        expect(closest.name).toBe('Test POI 2');
+      }
     });
   });
 });

--- a/client/__tests__/service_tests/PointsOfInterestService-test.tsx
+++ b/client/__tests__/service_tests/PointsOfInterestService-test.tsx
@@ -4,7 +4,6 @@ import { calculateEuclideanDistance } from '@/modules/map/MapUtils';
 import LocalLocations from '@/services/LocalLocations';
 import type { FeatureCollection, Point } from 'geojson';
 
-// Mock dependencies
 jest.mock('@/modules/map/MapUtils', () => ({
   calculateEuclideanDistance: jest.fn(),
 }));
@@ -45,6 +44,7 @@ jest.mock(
       {
         type: 'Feature',
         properties: {
+          name: 'Test POI 3',
           addr: '789 Test Blvd',
           opening_hours: 'Mo-Su 00:00-24:00',
           description: 'Public restaurant',
@@ -53,6 +53,34 @@ jest.mock(
         geometry: {
           type: 'Point',
           coordinates: [-74.026, 40.7148],
+        },
+      },
+      {
+        type: 'Feature',
+        properties: {
+          name: 'Weekend Evening POI',
+          addr: '999 Test Ave',
+          opening_hours: 'Fr-Su 18:00-24:00',
+          description: 'Night venue',
+          amenity: 'bar',
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [-74.036, 40.7158],
+        },
+      },
+      {
+        type: 'Feature',
+        properties: {
+          name: 'Wrapped Days POI',
+          addr: '888 Test Ave',
+          opening_hours: 'Su,Tu-Fr 09:00-17:00',
+          description: 'Wrapped days test',
+          amenity: 'cafe',
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [-74.046, 40.7168],
         },
       },
     ],
@@ -83,207 +111,163 @@ describe('PointsOfInterestService', () => {
     jest.clearAllMocks();
   });
 
-  describe('initialization', () => {
-    it('should initialize LocalLocations with all POIs from data', () => {
-      // Re-import the service to trigger the initialization code
-      jest.isolateModules(() => {
-        require('@/services/PointsOfInterestService');
-
-        const localLocationsInstance = LocalLocations.getInstance();
-        expect(localLocationsInstance.add).toHaveBeenCalledTimes(2); // Test POI 3 doesn't have a name property
-
-        // Test one call to verify the correct callback function
-        const firstCall = (localLocationsInstance.add as jest.Mock).mock.calls[0];
-        expect(firstCall[0]).toBe('Test POI 1');
-      });
-    });
+  afterEach(() => {
+    global.Date = originalDate;
   });
 
-  describe('isCurrentlyOpen function', () => {
-    it('should correctly determine when a POI is open on weekdays', () => {
-      // Mock a Monday at 12:00pm
-      const mockMonday = new Date(2025, 3, 7, 12, 0); // Monday, April 7, 2025, 12:00pm
-      global.Date = jest.fn(() => mockMonday) as unknown as typeof Date;
-
+  describe('initialization', () => {
+    it('initializes LocalLocations with POIs that have names', () => {
       jest.isolateModules(() => {
-        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
-
-        // Mock distance calculations to return POI 1 as closest
-        (calculateEuclideanDistance as jest.Mock).mockImplementation(
-          (coords: Coordinates, poiCoords: Coordinates) => {
-            if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002; // POI 1 (weekday 9-5)
-            return 1;
-          }
-        );
-
-        const userCoordinates: Coordinates = [-74.007, 40.713];
-        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-
-        expect(closest?.data.isOpen).toBe(true); // Should be open on Monday at noon
-      });
-    });
-
-    it('should correctly determine when a POI is closed on weekdays', () => {
-      // Mock a Monday at 6:00pm (after hours)
-      const mockMondayEvening = new Date(2025, 3, 7, 18, 0); // Monday, April 7, 2025, 6:00pm
-      global.Date = jest.fn(() => mockMondayEvening) as unknown as typeof Date;
-
-      jest.isolateModules(() => {
-        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
-
-        // Mock distance calculations to return POI 1 as closest
-        (calculateEuclideanDistance as jest.Mock).mockImplementation(
-          (coords: Coordinates, poiCoords: Coordinates) => {
-            if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002; // POI 1 (weekday 9-5)
-            return 1;
-          }
-        );
-
-        const userCoordinates: Coordinates = [-74.007, 40.713];
-        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-
-        expect(closest?.data.isOpen).toBe(false); // Should be closed at 6pm
-      });
-    });
-
-    it('should correctly determine when a POI is open on weekends', () => {
-      // Mock a Saturday at 12:00pm
-      const mockSaturday = new Date(2025, 3, 12, 12, 0); // Saturday, April 12, 2025, 12:00pm
-      global.Date = jest.fn(() => mockSaturday) as unknown as typeof Date;
-
-      jest.isolateModules(() => {
-        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
-
-        // Mock distance calculations to return POI 2 as closest
-        (calculateEuclideanDistance as jest.Mock).mockImplementation(
-          (coords: Coordinates, poiCoords: Coordinates) => {
-            if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0002; // POI 2 (weekend 10-6)
-            return 1;
-          }
-        );
-
-        const userCoordinates: Coordinates = [-74.017, 40.714];
-        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-
-        expect(closest?.data.isOpen).toBe(true); // Should be open on Saturday at noon
-      });
-    });
-
-    it('should correctly handle 24/7 locations', () => {
-      // Mock a random time
-      const mockTime = new Date(2025, 3, 8, 3, 30); // Tuesday, April 8, 2025, 3:30am
-      global.Date = jest.fn(() => mockTime) as unknown as typeof Date;
-
-      jest.isolateModules(() => {
-        const PointsOfInterestService = require('@/services/PointsOfInterestService').default;
-
-        // Mock distance calculations to return nameless POI with 24/7 hours
-        (calculateEuclideanDistance as jest.Mock).mockImplementation(
-          (coords: Coordinates, poiCoords: Coordinates) => {
-            if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0002; // 24/7 POI
-            return 1;
-          }
-        );
-
-        const userCoordinates: Coordinates = [-74.027, 40.715];
-        // Need to mock this POI since it has no name and won't be in LocalLocations
-        jest.spyOn(PointsOfInterestService, 'findClosestPOI').mockImplementation(() => ({
-          name: null,
-          coordinates: [-74.026, 40.7148],
-          data: {
-            address: '789 Test Blvd',
-            isOpen: true, // This would be calculated by the service
-            hours: 'Mo-Su 00:00-24:00',
-            category: 'Public restaurant',
-            type: 'restaurant',
-          },
-        }));
-
-        const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-        expect(closest?.data.hours).toBe('Mo-Su 00:00-24:00');
-        expect(closest?.data.isOpen).toBe(true);
+        require('@/services/PointsOfInterestService');
+        const localLocationsInstance = LocalLocations.getInstance();
+        expect(localLocationsInstance.add).toHaveBeenCalledTimes(5);
       });
     });
   });
 
   describe('findClosestPOI', () => {
-    beforeEach(() => {
-      // Restore original Date before these tests
-      global.Date = originalDate;
-    });
-
-    it('should return the closest POI within radius', () => {
+    it('returns closest POI within radius', () => {
       const userCoordinates: Coordinates = [-74.007, 40.713];
-
-      // Mock distance calculations for each POI
       (calculateEuclideanDistance as jest.Mock).mockImplementation(
         (coords: Coordinates, poiCoords: Coordinates) => {
-          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002; // POI 1 (closest)
-          if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0004; // POI 2
-          if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0008; // POI 3 (outside radius)
-          return 1; // Default
+          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0002;
+          return 0.001;
         }
       );
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-      expect(closest).not.toBeNull();
-      if (closest) {
-        expect(closest.name).toBe('Test POI 1');
-        expect(closest.coordinates).toEqual([-74.006, 40.7128]);
-        expect(closest.data.address).toBe('123 Test St');
-        expect(closest.data.hours).toBe('Mo-Fr 09:00-17:00');
-        expect(closest.data.category).toBe('Test description 1');
-        expect(closest.data.type).toBe('restaurant');
-      }
-      expect(calculateEuclideanDistance).toHaveBeenCalledTimes(3);
+      expect(closest?.name).toBe('Test POI 1');
     });
 
-    it('should return null if no POIs are within radius', () => {
+    it('returns null if no POIs are within radius', () => {
       const userCoordinates: Coordinates = [-74.007, 40.713];
-
-      // Mock all distances to be beyond radius
       (calculateEuclideanDistance as jest.Mock).mockReturnValue(0.001);
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
       expect(closest).toBeNull();
     });
 
-    it('should use default radius if none provided', () => {
+    it('uses default radius if none provided', () => {
       const userCoordinates: Coordinates = [-74.007, 40.713];
-
-      // Mock distance calculations
       (calculateEuclideanDistance as jest.Mock).mockImplementation(
         (coords: Coordinates, poiCoords: Coordinates) => {
-          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003; // Within default radius
+          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003;
           return 0.001;
         }
       );
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates);
-      expect(closest).not.toBeNull();
-      if (closest) {
-        expect(closest.name).toBe('Test POI 1');
-      }
+      expect(closest?.name).toBe('Test POI 1');
     });
 
-    it('should select the closest POI when multiple are within radius', () => {
+    it('selects closest POI when multiple are within radius', () => {
       const userCoordinates: Coordinates = [-74.007, 40.713];
-
-      // Mock multiple POIs within radius but with different distances
       (calculateEuclideanDistance as jest.Mock).mockImplementation(
         (coords: Coordinates, poiCoords: Coordinates) => {
-          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003; // POI 1
-          if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0002; // POI 2 (closest)
-          if (poiCoords[1] === 40.7148 && poiCoords[0] === -74.026) return 0.0004; // POI 3
-          return 1; // Default
+          if (poiCoords[1] === 40.7128 && poiCoords[0] === -74.006) return 0.0003;
+          if (poiCoords[1] === 40.7138 && poiCoords[0] === -74.016) return 0.0002;
+          return 0.001;
         }
       );
 
       const closest = PointsOfInterestService.findClosestPOI(userCoordinates, 0.0005);
-      expect(closest).not.toBeNull();
-      if (closest) {
-        expect(closest.name).toBe('Test POI 2');
-      }
+      expect(closest?.name).toBe('Test POI 2');
+    });
+  });
+
+  describe('getPOIByName', () => {
+    it('returns POI by name when it exists', () => {
+      const poi = PointsOfInterestService.getPOIByName('Test POI 1');
+      expect(poi?.name).toBe('Test POI 1');
+      expect(poi?.data.address).toBe('123 Test St');
+    });
+
+    it('returns null when POI name does not exist', () => {
+      const poi = PointsOfInterestService.getPOIByName('Nonexistent POI');
+      expect(poi).toBeNull();
+    });
+  });
+
+  describe('isCurrentlyOpen function', () => {
+    it('handles weekday open hours', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 7, 12, 0)) as unknown as typeof Date;
+      const poi = PointsOfInterestService.getPOIByName('Test POI 1');
+      expect(poi?.data.isOpen).toBe(true);
+    });
+
+    it('handles weekday closed hours', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 7, 18, 0)) as unknown as typeof Date;
+      const poi = PointsOfInterestService.getPOIByName('Test POI 1');
+      expect(poi?.data.isOpen).toBe(false);
+    });
+
+    it('handles weekend open hours', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 12, 12, 0)) as unknown as typeof Date;
+      const poi = PointsOfInterestService.getPOIByName('Test POI 2');
+      expect(poi?.data.isOpen).toBe(true);
+    });
+
+    it('handles 24/7 locations', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 8, 3, 30)) as unknown as typeof Date;
+      const poi = PointsOfInterestService.getPOIByName('Test POI 3');
+      expect(poi?.data.isOpen).toBe(true);
+    });
+
+    it('handles non-standard day ranges', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 13, 12, 0)) as unknown as typeof Date;
+      const poi = PointsOfInterestService.getPOIByName('Wrapped Days POI');
+      expect(poi?.data.isOpen).toBe(true);
+    });
+
+    it('handles evening hours', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 11, 20, 0)) as unknown as typeof Date;
+      const poi = PointsOfInterestService.getPOIByName('Weekend Evening POI');
+      expect(poi?.data.isOpen).toBe(true);
+    });
+
+    it('handles null opening hours', () => {
+      const testFeature = {
+        type: 'Feature',
+        properties: {
+          name: 'No Hours POI',
+          addr: '555 Test Ave',
+          description: 'No hours test',
+          amenity: 'cafe',
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [-74.056, 40.7178],
+        },
+      };
+
+      const location = (PointsOfInterestService as any).extractLocation(testFeature);
+      expect(location.data.isOpen).toBe(false);
+    });
+  });
+
+  describe('isCurrentDayInRange', () => {
+    it('handles invalid day codes', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 7, 12, 0)) as unknown as typeof Date;
+      const testPoi = (PointsOfInterestService as any).isCurrentDayInRange('InvalidDay', 'Mo-Fr');
+      expect(testPoi).toBe(false);
+    });
+
+    it('handles invalid day range', () => {
+      global.Date = jest.fn(() => new Date(2025, 3, 7, 12, 0)) as unknown as typeof Date;
+      const testPoi = (PointsOfInterestService as any).isCurrentDayInRange('Mo', 'XX-YY');
+      expect(testPoi).toBe(false);
+    });
+  });
+
+  describe('isInDayRange', () => {
+    it('handles standard day ranges', () => {
+      const result = (PointsOfInterestService as any).isInDayRange(2, 1, 5);
+      expect(result).toBe(true);
+    });
+
+    it('handles wrapped day ranges', () => {
+      const result = (PointsOfInterestService as any).isInDayRange(0, 5, 1);
+      expect(result).toBe(true);
     });
   });
 });

--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -6,8 +6,7 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.READ_CALENDAR" />
-  <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.READ_CALENDAR" />
+  <uses-permission android:name="android.permission.WRITE_CALENDAR" />
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/client/assets/geojson/pois.json
+++ b/client/assets/geojson/pois.json
@@ -6,7 +6,7 @@
       "properties": {
         "name": "Unnamed Park",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Public park",
         "amenity": "park"
       },
@@ -20,7 +20,7 @@
       "properties": {
         "name": "Unnamed Park",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Public park",
         "amenity": "park"
       },
@@ -34,7 +34,7 @@
       "properties": {
         "name": "Parc Percy-Walters",
         "addr": "40 Avenue McGregor, Montréal, Québec, H3G 2J8",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Public park (https://montreal.ca/en/places/parc-percy-walters)",
         "amenity": "park"
       },
@@ -48,7 +48,7 @@
       "properties": {
         "name": "3 Brasseurs",
         "addr": "1356 Rue Sainte-Catherine Ouest, Montréal, Québec, H3G 1P6",
-        "opening_hours": "Mo-Su 11:00-01:00",
+        "opening_hours": "24/7",
         "description": "Burger, Pizza;seafood restaurant (https://www.les3brasseurs.ca/fr/trouver-un-3-brasseurs/crescent/)",
         "amenity": "restaurant"
       },
@@ -62,7 +62,7 @@
       "properties": {
         "name": "Le Garden Room",
         "addr": "1445 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 12:00-02:00",
+        "opening_hours": "24/7",
         "description": "Thai restaurant (https://www.legardenroom.com/)",
         "amenity": "restaurant"
       },
@@ -76,7 +76,7 @@
       "properties": {
         "name": "Station Guy-Concordia (St-Mathieu/De Maisonneuve)",
         "addr": "Guy-Concordia, 1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -90,7 +90,7 @@
       "properties": {
         "name": "Station Guy-Concordia (Guy / De Maisonneuve)",
         "addr": "Guy-Concordia, 1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -104,7 +104,7 @@
       "properties": {
         "name": "Sushi Ste-Catherine",
         "addr": "1801 Saint-Catherine St W, Montreal, Quebec H3H 1M2",
-        "opening_hours": "Mo-Su 11:00-23:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -118,7 +118,7 @@
       "properties": {
         "name": "Les Trois amigos",
         "addr": "1657 Rue Sainte-Catherine Ouest, Montréal, QC, H3H 2H8",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Mexican restaurant (http://www.3amigosrestaurant.com)",
         "amenity": "restaurant"
       },
@@ -132,7 +132,7 @@
       "properties": {
         "name": "BBQ Coréen PONY",
         "addr": "1608 Saint-Catherine St W, Montreal, Quebec H3H 2S7",
-        "opening_hours": "Mo-Su 11:30-23:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -146,7 +146,7 @@
       "properties": {
         "name": "Webster Library",
         "addr": "Pavillion J.W. McConnell Bldg, 1400 Maisonneuve Blvd W, Montreal, Quebec H3G 1M8",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Public library",
         "amenity": "library"
       },
@@ -160,7 +160,7 @@
       "properties": {
         "name": "Wienstein & Gavino's",
         "addr": "1434 Crescent Street, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Italian restaurant (https://www.wgmtl.com/)",
         "amenity": "restaurant"
       },
@@ -174,7 +174,7 @@
       "properties": {
         "name": "Ocha Bubble Tea",
         "addr": "1651 Rue Sainte-Catherine Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Bubble_tea restaurant",
         "amenity": "restaurant"
       },
@@ -188,7 +188,7 @@
       "properties": {
         "name": "Le Pois Penché",
         "addr": "1230 Blvd. De Maisonneuve Ouest, Montreal, Quebec H3G 1V9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -202,7 +202,7 @@
       "properties": {
         "name": "Nara Reto Lounge",
         "addr": "1333 Boulevard De Maisonneuve Ouest, Montréal, Québec, H3G 2R9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Mediterranean restaurant",
         "amenity": "restaurant"
       },
@@ -216,7 +216,7 @@
       "properties": {
         "name": "Toro Sushi",
         "addr": "2045 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Sushi restaurant",
         "amenity": "restaurant"
       },
@@ -230,7 +230,7 @@
       "properties": {
         "name": "Bice Restaurant",
         "addr": "1504 Rue Sherbrooke Ouest, Montréal, Québec, H3G 1L3",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -244,7 +244,7 @@
       "properties": {
         "name": "Troika",
         "addr": "2171 Rue Crescent, Montréal, Québec, H3G 2C1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "French restaurant",
         "amenity": "restaurant"
       },
@@ -258,7 +258,7 @@
       "properties": {
         "name": "L'Autre Saison",
         "addr": "2137 Rue Crescent, Montréal, Québec, H3G 2C1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "French restaurant",
         "amenity": "restaurant"
       },
@@ -272,7 +272,7 @@
       "properties": {
         "name": "L'Académie",
         "addr": "2100 Rue Crescent, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "International restaurant",
         "amenity": "restaurant"
       },
@@ -286,7 +286,7 @@
       "properties": {
         "name": "Restaurant Santa Lucia",
         "addr": "1264 Rue Stanley, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Italian restaurant",
         "amenity": "restaurant"
       },
@@ -300,7 +300,7 @@
       "properties": {
         "name": "Station Guy-Concordia (Guy / De Maisonneuve)",
         "addr": "1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -314,7 +314,7 @@
       "properties": {
         "name": "Côte-des-Neiges / Summerhill",
         "addr": "Montreal, QC H3H 1T9",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -328,7 +328,7 @@
       "properties": {
         "name": "Pho Nguyen",
         "addr": "1452 Rue Saint-Mathieu, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Vietnamese restaurant",
         "amenity": "restaurant"
       },
@@ -342,7 +342,7 @@
       "properties": {
         "name": "Shifu",
         "addr": "1460 Rue Mackay, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-23:00",
+        "opening_hours": "24/7",
         "description": "Chinese restaurant",
         "amenity": "restaurant"
       },
@@ -356,7 +356,7 @@
       "properties": {
         "name": "Sushi Crescent",
         "addr": "1437 Crescent St, Montreal, Quebec H3G 2B2",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -370,7 +370,7 @@
       "properties": {
         "name": "Devi",
         "addr": "1450 Crescent St, Montreal, Quebec H3G 1R1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Indian restaurant (http://devimontreal.com/)",
         "amenity": "restaurant"
       },
@@ -384,7 +384,7 @@
       "properties": {
         "name": "Qinghua Dumplings (Express)",
         "addr": "1909 Rue Sainte-Catherine Ouest, Montréal, Québec, H3H 1M3",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Asian, Dumpling restaurant",
         "amenity": "restaurant"
       },
@@ -398,7 +398,7 @@
       "properties": {
         "name": "Restaurant Qinghua Dumpling",
         "addr": "1676 Avenue Lincoln, Montréal, Québec, H3H 1G9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Asian, Dumpling restaurant",
         "amenity": "restaurant"
       },
@@ -412,7 +412,7 @@
       "properties": {
         "name": "Burritoville",
         "addr": "2055 Rue Bishop, Montréal, QC, H3G 2E9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -426,7 +426,7 @@
       "properties": {
         "name": "Eggspectation",
         "addr": "1313 De Maisonneuve West, Montréal, Québec",
-        "opening_hours": "Mo-Su 06:00-17:00",
+        "opening_hours": "24/7",
         "description": "Breakfast restaurant",
         "amenity": "restaurant"
       },
@@ -440,7 +440,7 @@
       "properties": {
         "name": "Allô! Mon Coco",
         "addr": "1684 Boulevard De Masonneuve Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 06:00-16:00",
+        "opening_hours": "24/7",
         "description": "Breakfast restaurant (https://allomoncoco.com/)",
         "amenity": "restaurant"
       },
@@ -454,7 +454,7 @@
       "properties": {
         "name": "Château Kabab",
         "addr": "2140 Guy St, Montreal, Quebec H3H 2N4",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Persian restaurant",
         "amenity": "restaurant"
       },
@@ -468,7 +468,7 @@
       "properties": {
         "name": "René-Lévesque / Bishop",
         "addr": "Montreal, QC H3G 2M5",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -482,7 +482,7 @@
       "properties": {
         "name": "Ferrari Restaurant - Café",
         "addr": "1407 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Italian restaurant (https://restoferrari.ca/)",
         "amenity": "restaurant"
       },
@@ -496,7 +496,7 @@
       "properties": {
         "name": "Man-na",
         "addr": "1421 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Korean restaurant",
         "amenity": "restaurant"
       },
@@ -510,7 +510,7 @@
       "properties": {
         "name": "Pizza Hut",
         "addr": "1431 Rue bishop, Montréal, Québec, H3G 2E4",
-        "opening_hours": "Mo-Su 10:30-24:00",
+        "opening_hours": "24/7",
         "description": "Pizza restaurant (https://www.pizzahut.ca/huts/ca-1/R34601/)",
         "amenity": "restaurant"
       },
@@ -524,7 +524,7 @@
       "properties": {
         "name": "Messa 14",
         "addr": "1425 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Mexican restaurant (http://www.mesa14.com/)",
         "amenity": "restaurant"
       },
@@ -538,7 +538,7 @@
       "properties": {
         "name": "Maison Chaïshaï",
         "addr": "2005 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Indian restaurant (http://www.ordercharcos.com/)",
         "amenity": "restaurant"
       },
@@ -552,7 +552,7 @@
       "properties": {
         "name": "Maison Inja - Cuisine Perse",
         "addr": "1458 Sherbrooke St W, Montreal, Quebec H3G 2S8",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -566,7 +566,7 @@
       "properties": {
         "name": "Cocktail Hawaii",
         "addr": "1645 Maisonneuve Blvd W, Montreal, Quebec H3H 2N3",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -580,7 +580,7 @@
       "properties": {
         "name": "NosThés",
         "addr": "1609 Saint-Catherine St W, Montreal, Quebec H3H 1L8",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -594,7 +594,7 @@
       "properties": {
         "name": "Restaurant Traditions",
         "addr": "2330 Guy St, Montreal, Quebec H3H 1E1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Mediterranean restaurant",
         "amenity": "restaurant"
       },
@@ -608,7 +608,7 @@
       "properties": {
         "name": "Chez Chen",
         "addr": "1618 Avenue Lincoln, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Chinese restaurant",
         "amenity": "restaurant"
       },
@@ -622,7 +622,7 @@
       "properties": {
         "name": "Angela Pizzeria & Restaurant",
         "addr": "1662 Boulevard de Maisonneuve O, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Pizza restaurant",
         "amenity": "restaurant"
       },
@@ -636,7 +636,7 @@
       "properties": {
         "name": "Student Tasty Biryani",
         "addr": "1620 Avenue Lincoln, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -650,7 +650,7 @@
       "properties": {
         "name": "Comptoir du chef",
         "addr": "2153 Guy St, Montreal, Quebec H3H 2R9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -664,7 +664,7 @@
       "properties": {
         "name": "Thali Cuisine Indienne",
         "addr": "1409 Rue Saint-Marc, Montréal, QC, H3H 2G4",
-        "opening_hours": "Tu-Su 11:30-22:00",
+        "opening_hours": "24/7",
         "description": "Indian restaurant (https://www.thalimontreal.com)",
         "amenity": "restaurant"
       },
@@ -678,7 +678,7 @@
       "properties": {
         "name": "Ici Restaurant Coréen",
         "addr": "1413 Rue Saint-Marc, Montréal, QC, H3H 1M1",
-        "opening_hours": "Mo-Su 11:00-21:00",
+        "opening_hours": "24/7",
         "description": "Korean restaurant",
         "amenity": "restaurant"
       },
@@ -692,7 +692,7 @@
       "properties": {
         "name": "La Belle et le Bœuf",
         "addr": "1620 Saint-Catherine St W, Montreal, Quebec H3A 1L9",
-        "opening_hours": "Mo-Su 12:30-24:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -706,7 +706,7 @@
       "properties": {
         "name": "Burger bar crescent",
         "addr": "1465 Rue Crescent, Montréal, Québec, H3G 2B2",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -734,7 +734,7 @@
       "properties": {
         "name": "Yama",
         "addr": "1415 Rue de la Montagne, Montréal, QC H3G 1Z3",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -748,7 +748,7 @@
       "properties": {
         "name": "COQCOR",
         "addr": "1237 Rue Guy, Montréal, Québec, H3H 2K5",
-        "opening_hours": "Mo-Su 12:00-22:00",
+        "opening_hours": "24/7",
         "description": "Korean_fried_chicken restaurant",
         "amenity": "restaurant"
       },
@@ -762,7 +762,7 @@
       "properties": {
         "name": "Chez la Mere Michel",
         "addr": "1209 Rue Guy, Montréal, Québec, H3H 2K5",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -776,7 +776,7 @@
       "properties": {
         "name": "Trattoria Trestevere",
         "addr": "1237 Crescent St, Montreal, Quebec H3G 2B1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Italian restaurant",
         "amenity": "restaurant"
       },
@@ -790,7 +790,7 @@
       "properties": {
         "name": "Pizza Chez Danny",
         "addr": "1237 Rue de la Montagne, Montréal, QC H3G 1P1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -804,7 +804,7 @@
       "properties": {
         "name": "Chez Hailar",
         "addr": "1612 Rue Sherbrooke Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-23:00",
+        "opening_hours": "24/7",
         "description": "Restaurant (http://www.chezhailar.com)",
         "amenity": "restaurant"
       },
@@ -818,7 +818,7 @@
       "properties": {
         "name": "Sherbrooke / Bishop",
         "addr": "Montreal, QC H3G 1K4",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -832,7 +832,7 @@
       "properties": {
         "name": "Kinton Ramen",
         "addr": "1211 Bishop St, Montreal, Quebec H3G 2E2",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Ramen restaurant",
         "amenity": "restaurant"
       },
@@ -846,7 +846,7 @@
       "properties": {
         "name": "Chez Cora",
         "addr": "1240 Drummond St, Montreal, Quebec H3G 1V7",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Breakfast restaurant (https://www.chezcora.com/)",
         "amenity": "restaurant"
       },
@@ -860,7 +860,7 @@
       "properties": {
         "name": "Schlouppe Bistrot",
         "addr": "2159 Rue Mackay, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Japanese restaurant",
         "amenity": "restaurant"
       },
@@ -874,7 +874,7 @@
       "properties": {
         "name": "Chai Paratha",
         "addr": "2340 Rue Guy, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Pakistani restaurant",
         "amenity": "restaurant"
       },
@@ -888,7 +888,7 @@
       "properties": {
         "name": "K2 Sushi",
         "addr": "1468 Rue Crescent, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Sushi restaurant",
         "amenity": "restaurant"
       },
@@ -902,7 +902,7 @@
       "properties": {
         "name": "Otto Yakitori",
         "addr": "1441 Rue Saint-Mathieu, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -916,7 +916,7 @@
       "properties": {
         "name": "René-Lévesque / Guy",
         "addr": "Montreal, QC",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -930,7 +930,7 @@
       "properties": {
         "name": "Sherbrooke / Côte-des-Neiges",
         "addr": "Montreal, QC H3H 1T4",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -944,7 +944,7 @@
       "properties": {
         "name": "Sherbrooke / Saint-Mathieu",
         "addr": "Montreal, QC H3H 1E4",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -958,7 +958,7 @@
       "properties": {
         "name": "Station Guy-Concordia (Maisonneuve / St-Mathieu)",
         "addr": "Accès A, 1801 St Mathieu St, Montreal, Quebec H3H 1J9",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -972,7 +972,7 @@
       "properties": {
         "name": "Guy / Sainte-Catherine",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -986,7 +986,7 @@
       "properties": {
         "name": "De Maisonneuve / de la Montagne",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1000,7 +1000,7 @@
       "properties": {
         "name": "Sainte-Catherine / Saint-Mathieu",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1014,7 +1014,7 @@
       "properties": {
         "name": "René-Lévesque / Guy",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1028,7 +1028,7 @@
       "properties": {
         "name": "De Maisonneuve / Bishop",
         "addr": "De Maisonneuve / Bishop",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1042,7 +1042,7 @@
       "properties": {
         "name": "Station Guy-Concordia (De Maisonneuve/St-Mathieu)",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1056,7 +1056,7 @@
       "properties": {
         "name": "Guy / René-Lévesque",
         "addr": "Montreal, QC H3H 2K7",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1070,7 +1070,7 @@
       "properties": {
         "name": "Saint-Mathieu / Sherbrooke",
         "addr": "Montreal, QC H3H 1E3",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1084,7 +1084,7 @@
       "properties": {
         "name": "Sherbrooke / Saint-Marc",
         "addr": "Montreal, QC H3H 1E3",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1098,7 +1098,7 @@
       "properties": {
         "name": "du Docteur-Penfield / Redpath",
         "addr": "Montreal, QC H3G 1B8",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1112,7 +1112,7 @@
       "properties": {
         "name": "Sainte-Catherine / de la Montagne",
         "addr": "Montreal, QC H3G 1P6",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1126,7 +1126,7 @@
       "properties": {
         "name": "Poke Monster",
         "addr": "1225 Blvd. De Maisonneuve Ouest, Montreal, Quebec H3G 1M3",
-        "opening_hours": "Mo-Su 110:00-17:00",
+        "opening_hours": "24/70",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1140,7 +1140,7 @@
       "properties": {
         "name": "La Medusa",
         "addr": "1218 Drummond St, Montreal, Quebec H3G 1V7",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Italian, Pizza restaurant (https://www.lamedusa.ca/)",
         "amenity": "restaurant"
       },
@@ -1154,7 +1154,7 @@
       "properties": {
         "name": "Parma Café",
         "addr": "1202 Bishop St, Montreal, Quebec H3G 2E3",
-        "opening_hours": "Mo-Su 08:00-21:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1168,7 +1168,7 @@
       "properties": {
         "name": "Qing Hua Dumpling",
         "addr": "1675 Boulevard De Maisonneuve Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1182,7 +1182,7 @@
       "properties": {
         "name": "KimGalbi",
         "addr": "2100 Rue Saint-Mathieu, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1196,7 +1196,7 @@
       "properties": {
         "name": "Guy-Concordia",
         "addr": "1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "Mo-Su 05:00-02:00",
+        "opening_hours": "24/7",
         "description": "Metro station",
         "amenity": "subway_station"
       },
@@ -1210,7 +1210,7 @@
       "properties": {
         "name": "Cuisine AuntDai",
         "addr": "1448 Rue Saint-Mathieu, Montréal, Québec, H3H 2H9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Chinese restaurant (http://auntdai.com)",
         "amenity": "restaurant"
       },
@@ -1238,7 +1238,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1252,7 +1252,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station with 45 docks",
         "amenity": "bicycle_rental"
       },
@@ -1266,7 +1266,7 @@
       "properties": {
         "name": "OFish Bishop",
         "addr": "1429 A Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1280,7 +1280,7 @@
       "properties": {
         "name": "Sana",
         "addr": "1175A Rue Crescent, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Pakistani, Indian; bangladeshi restaurant",
         "amenity": "restaurant"
       },
@@ -1294,7 +1294,7 @@
       "properties": {
         "name": "Notre Endroit",
         "addr": "1437 Boulevard René-Lévesque Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-23:00",
+        "opening_hours": "24/7",
         "description": "Indian, South_indian restaurant",
         "amenity": "restaurant"
       },
@@ -1308,7 +1308,7 @@
       "properties": {
         "name": "Escondite",
         "addr": "1224 Rue Drummond, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Mexican restaurant",
         "amenity": "restaurant"
       },
@@ -1322,7 +1322,7 @@
       "properties": {
         "name": "Misoya",
         "addr": "2065A Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Ramen restaurant",
         "amenity": "restaurant"
       },
@@ -1336,7 +1336,7 @@
       "properties": {
         "name": "Chef Istanbul",
         "addr": "1510 Blvd. De Maisonneuve Ouest, Montreal, Quebec H3G 1N1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Turkish restaurant",
         "amenity": "restaurant"
       },
@@ -1350,7 +1350,7 @@
       "properties": {
         "name": "Mon Ami",
         "addr": "1488 Rue Sainte-Catherine Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1364,7 +1364,7 @@
       "properties": {
         "name": "Crossbar",
         "addr": "1390 Boulevard René-Lévesque Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1378,7 +1378,7 @@
       "properties": {
         "name": "Gyu-Kaku",
         "addr": "1255 Rue Crescent, Montréal, Québec, H3G 2B1",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Japanese, Barbecue restaurant (https://www.gyu-kaku.com/montreal/)",
         "amenity": "restaurant"
       },
@@ -1392,7 +1392,7 @@
       "properties": {
         "name": "Downtown Dhaba",
         "addr": "1668 Boul. de Maisonneuve Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Su 11:00-23:00",
+        "opening_hours": "24/7",
         "description": "Indian restaurant (https://downtowndhaba.com/)",
         "amenity": "restaurant"
       },
@@ -1406,7 +1406,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1420,7 +1420,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1434,7 +1434,7 @@
       "properties": {
         "name": "Bis Ristorante",
         "addr": "1229 Rue de la Montagne, Montréal, QC H3G 1Z2",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Italian restaurant",
         "amenity": "restaurant"
       },
@@ -1448,7 +1448,7 @@
       "properties": {
         "name": "Sushi Rosa",
         "addr": "1231 Drummond St, Montreal, Quebec H3G 1V8",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Sushi restaurant",
         "amenity": "restaurant"
       },
@@ -1462,7 +1462,7 @@
       "properties": {
         "name": "Poke Bento",
         "addr": "1452 St Mathieu St B, Montreal, Quebec H3H 2H9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1476,7 +1476,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1490,7 +1490,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station with 19 docks",
         "amenity": "bicycle_rental"
       },
@@ -1504,7 +1504,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station with 31 docks",
         "amenity": "bicycle_rental"
       },
@@ -1518,7 +1518,7 @@
       "properties": {
         "name": "I am Pho",
         "addr": "1444 St Mathieu St, Montreal, Quebec H3H 2H9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Vietnamese restaurant",
         "amenity": "restaurant"
       },
@@ -1532,7 +1532,7 @@
       "properties": {
         "name": "DonDonYa",
         "addr": "1433A Bishop St, Montreal, Quebec H3G 2E4",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1546,7 +1546,7 @@
       "properties": {
         "name": "Chatpata",
         "addr": "1620 Av. Lincoln, Montréal, QC H3H 1G9",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Chinese, Indian restaurant",
         "amenity": "restaurant"
       },
@@ -1560,7 +1560,7 @@
       "properties": {
         "name": "La Hueca by Masa",
         "addr": "Le Faubourg Sainte Catherine, 1616 Saint-Catherine St W, Montreal, Quebec H3H 1L7",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1574,7 +1574,7 @@
       "properties": {
         "name": "Patty Slaps",
         "addr": "1449 Saint-Catherine St W, Montreal, Quebec H3G 1S6",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1588,7 +1588,7 @@
       "properties": {
         "name": "Chimaek Gana",
         "addr": "2080 St Mathieu St, Montreal, Quebec H3H 2J4",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Chicken restaurant",
         "amenity": "restaurant"
       },
@@ -1602,7 +1602,7 @@
       "properties": {
         "name": "Hazukido",
         "addr": "1629 Saint-Catherine St W, Montreal, Quebec H3H 1L8",
-        "opening_hours": "Mo-Su 09:00-19:00",
+        "opening_hours": "24/7",
         "description": "Dessert, Bubble_tea restaurant",
         "amenity": "restaurant"
       },
@@ -1616,7 +1616,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1630,7 +1630,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1644,7 +1644,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1658,7 +1658,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bike sharing station with 19 docks",
         "amenity": "bicycle_rental"
       },
@@ -1672,7 +1672,7 @@
       "properties": {
         "name": "Garage Beirut",
         "addr": "1238 Rue Mackay, Montréal, QC, H3G 2H4",
-        "opening_hours": "Mo-Su 11:00-22:00",
+        "opening_hours": "24/7",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1686,7 +1686,7 @@
       "properties": {
         "name": "Fondue Haidilao",
         "addr": "1194 Saint-Catherine St W, Montreal, Quebec H3B 1K1",
-        "opening_hours": "Mo-Su 11:00-04:00",
+        "opening_hours": "24/7",
         "description": "Asian restaurant",
         "amenity": "restaurant"
       },
@@ -1700,7 +1700,7 @@
       "properties": {
         "name": "sparta chicken",
         "addr": "1235 Rue Guy, Montréal, Québec, H3H 2K5",
-        "opening_hours": "Mo-Su 13:00-03:00",
+        "opening_hours": "24/7",
         "description": "Greek_fried_chiken restaurant",
         "amenity": "restaurant"
       },
@@ -1714,7 +1714,7 @@
       "properties": {
         "name": "Cafe Myriade",
         "addr": "1432 Mackay St, Montreal, Quebec H3G 2H7",
-        "opening_hours": "Mo-Su 08:00-19:00",
+        "opening_hours": "24/7",
         "description": "Fresh-roasted coffees brewed in a contemporary space, plus baked goods & croissants.",
         "amenity": "restaurant"
       },
@@ -1728,7 +1728,7 @@
       "properties": {
         "name": "McKibbin's",
         "addr": "1426 Bishop St, Montreal, Quebec H3G 2E6",
-        "opening_hours": "Mo-Su 11:30–03:00",
+        "opening_hours": "24/7",
         "description": "Cozy, woodsy pub (part of a local chain) for Celtic comfort food, live music, pitchers & TV sports.",
         "amenity": "restaurant"
       },
@@ -1742,7 +1742,7 @@
       "properties": {
         "name": "Starbucks",
         "addr": "1457 Saint-Catherine St W, Montreal, Quebec H3G 1S6",
-        "opening_hours": "Mo-Su 06:30-22:00",
+        "opening_hours": "24/7",
         "description": "Seattle-based coffeehouse chain known for its signature roasts, light bites and WiFi availability.",
         "amenity": "restaurant"
       },
@@ -1756,7 +1756,7 @@
       "properties": {
         "name": "Starbucks",
         "addr": "2000 Guy St, Montreal, Quebec H3H 2N4",
-        "opening_hours": "Mo-Su 06:30-22:00",
+        "opening_hours": "24/7",
         "description": "Seattle-based coffeehouse chain known for its signature roasts, light bites and WiFi availability.",
         "amenity": "restaurant"
       },
@@ -1770,7 +1770,7 @@
       "properties": {
         "name": "Java U Guy",
         "addr": "1455 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "Mo-Su 07:00-21:00",
+        "opening_hours": "24/7",
         "description": "Cafe",
         "amenity": "restaurant"
       },
@@ -1784,7 +1784,7 @@
       "properties": {
         "name": "A&W",
         "addr": "1550 Blvd. De Maisonneuve Ouest #101, Montreal, Quebec H3G 1N1",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Fast-food outlet serving up namesake root beer, plus burgers, chicken & fries.",
         "amenity": "restaurant"
       },
@@ -1798,7 +1798,7 @@
       "properties": {
         "name": "Matcha Zanmai",
         "addr": "1428 Mackay St, Montreal, Quebec H3G 2H9",
-        "opening_hours": "Mo-Su 12:00-22:00",
+        "opening_hours": "24/7",
         "description": "Japanese sweets restaurant",
         "amenity": "restaurant"
       },
@@ -1812,7 +1812,7 @@
       "properties": {
         "name": "Ganadara",
         "addr": "1417 Mackay St, Montreal, Quebec H3G 0H2",
-        "opening_hours": "Mo-Su 11:30-20:30",
+        "opening_hours": "24/7",
         "description": "Hearty Korean favourites, from seafood pancakes to bibimbop, dished up in a bustling, compact venue.",
         "amenity": "restaurant"
       },
@@ -1826,7 +1826,7 @@
       "properties": {
         "name": "Vanier Library",
         "addr": "7141 Sherbrooke St W, Montreal, Quebec H4B 1R6",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Loyola Campus University Library",
         "amenity": "library"
       },
@@ -1854,7 +1854,7 @@
       "properties": {
         "name": "Subway",
         "addr": "7420 Sherbrooke St W, Montreal, Quebec H4B 1R7",
-        "opening_hours": "Mo-Su 07:00-22:00",
+        "opening_hours": "24/7",
         "description": "Casual counter-serve chain for build-your-own sandwiches & salads, with health-conscious options.",
         "amenity": "restaurant"
       },
@@ -1868,7 +1868,7 @@
       "properties": {
         "name": "Université Concordia / Campus Loyola",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1882,7 +1882,7 @@
       "properties": {
         "name": "Université Concordia / Campus Loyola",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1896,7 +1896,7 @@
       "properties": {
         "name": "Sherbrooke / West Broadway",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1910,7 +1910,7 @@
       "properties": {
         "name": "West Broadway / Sherbrooke",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1924,7 +1924,7 @@
       "properties": {
         "name": "West Broadway / De Terrebonne",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1938,7 +1938,7 @@
       "properties": {
         "name": "Souvlaki George® Restaurant",
         "addr": "6995 Monkland Ave, Montreal, Quebec H4B 1J8",
-        "opening_hours": "Mo-Su 11:00-21:00",
+        "opening_hours": "24/7",
         "description": "Quick-serve grilled kebab platters, gyro pita combos & North American eats in an informal space.",
         "amenity": "restaurant"
       },
@@ -1952,7 +1952,7 @@
       "properties": {
         "name": "Dagwoods La Sandwicherie",
         "addr": "6969 Sherbrooke St W, Montreal, Quebec H4B 1R1",
-        "opening_hours": "Mo-Su 11:00-21:00",
+        "opening_hours": "24/7",
         "description": "Sandwhich Shop.",
         "amenity": "restaurant"
       },
@@ -1966,7 +1966,7 @@
       "properties": {
         "name": "Recreational park / Parc de loisirs -Concordia University - Loyola Campus",
         "addr": "Montreal, Quebec H4B 1E1",
-        "opening_hours": "Mo-Su 00:00-24:00",
+        "opening_hours": "24/7",
         "description": "Public park, Dogs Allowed",
         "amenity": "park"
       },

--- a/client/assets/geojson/pois.json
+++ b/client/assets/geojson/pois.json
@@ -6,7 +6,7 @@
       "properties": {
         "name": "Unnamed Park",
         "addr": "Address unavailable",
-        "opening_hours": "Dawn to dusk",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Public park",
         "amenity": "park"
       },
@@ -20,7 +20,7 @@
       "properties": {
         "name": "Unnamed Park",
         "addr": "Address unavailable",
-        "opening_hours": "Dawn to dusk",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Public park",
         "amenity": "park"
       },
@@ -34,7 +34,7 @@
       "properties": {
         "name": "Parc Percy-Walters",
         "addr": "40 Avenue McGregor, Montréal, Québec, H3G 2J8",
-        "opening_hours": "Mo-Su 06:00-23:00",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Public park (https://montreal.ca/en/places/parc-percy-walters)",
         "amenity": "park"
       },
@@ -48,7 +48,7 @@
       "properties": {
         "name": "3 Brasseurs",
         "addr": "1356 Rue Sainte-Catherine Ouest, Montréal, Québec, H3G 1P6",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-01:00",
         "description": "Burger, Pizza;seafood restaurant (https://www.les3brasseurs.ca/fr/trouver-un-3-brasseurs/crescent/)",
         "amenity": "restaurant"
       },
@@ -62,7 +62,7 @@
       "properties": {
         "name": "Le Garden Room",
         "addr": "1445 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Mo-We 12:00-23:00; Th-Su 12:00-02:00",
+        "opening_hours": "Mo-Su 12:00-02:00",
         "description": "Thai restaurant (https://www.legardenroom.com/)",
         "amenity": "restaurant"
       },
@@ -76,7 +76,7 @@
       "properties": {
         "name": "Station Guy-Concordia (St-Mathieu/De Maisonneuve)",
         "addr": "Guy-Concordia, 1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -90,7 +90,7 @@
       "properties": {
         "name": "Station Guy-Concordia (Guy / De Maisonneuve)",
         "addr": "Guy-Concordia, 1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -104,7 +104,7 @@
       "properties": {
         "name": "Sushi Ste-Catherine",
         "addr": "1801 Saint-Catherine St W, Montreal, Quebec H3H 1M2",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-23:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -118,7 +118,7 @@
       "properties": {
         "name": "Les Trois amigos",
         "addr": "1657 Rue Sainte-Catherine Ouest, Montréal, QC, H3H 2H8",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Mexican restaurant (http://www.3amigosrestaurant.com)",
         "amenity": "restaurant"
       },
@@ -132,7 +132,7 @@
       "properties": {
         "name": "BBQ Coréen PONY",
         "addr": "1608 Saint-Catherine St W, Montreal, Quebec H3H 2S7",
-        "opening_hours": "Mo-We 17:00-23:00, Th 17:00-24:00, Fr,Sa 11:30-01:00, Su 11:30-23:00",
+        "opening_hours": "Mo-Su 11:30-23:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -146,7 +146,7 @@
       "properties": {
         "name": "Webster Library",
         "addr": "Pavillion J.W. McConnell Bldg, 1400 Maisonneuve Blvd W, Montreal, Quebec H3G 1M8",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Public library",
         "amenity": "library"
       },
@@ -160,7 +160,7 @@
       "properties": {
         "name": "Wienstein & Gavino's",
         "addr": "1434 Crescent Street, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Italian restaurant (https://www.wgmtl.com/)",
         "amenity": "restaurant"
       },
@@ -174,7 +174,7 @@
       "properties": {
         "name": "Ocha Bubble Tea",
         "addr": "1651 Rue Sainte-Catherine Ouest, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Bubble_tea restaurant",
         "amenity": "restaurant"
       },
@@ -188,7 +188,7 @@
       "properties": {
         "name": "Le Pois Penché",
         "addr": "1230 Blvd. De Maisonneuve Ouest, Montreal, Quebec H3G 1V9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -202,7 +202,7 @@
       "properties": {
         "name": "Nara Reto Lounge",
         "addr": "1333 Boulevard De Maisonneuve Ouest, Montréal, Québec, H3G 2R9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Mediterranean restaurant",
         "amenity": "restaurant"
       },
@@ -216,7 +216,7 @@
       "properties": {
         "name": "Toro Sushi",
         "addr": "2045 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Sushi restaurant",
         "amenity": "restaurant"
       },
@@ -230,7 +230,7 @@
       "properties": {
         "name": "Bice Restaurant",
         "addr": "1504 Rue Sherbrooke Ouest, Montréal, Québec, H3G 1L3",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -244,7 +244,7 @@
       "properties": {
         "name": "Troika",
         "addr": "2171 Rue Crescent, Montréal, Québec, H3G 2C1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "French restaurant",
         "amenity": "restaurant"
       },
@@ -258,7 +258,7 @@
       "properties": {
         "name": "L'Autre Saison",
         "addr": "2137 Rue Crescent, Montréal, Québec, H3G 2C1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "French restaurant",
         "amenity": "restaurant"
       },
@@ -272,7 +272,7 @@
       "properties": {
         "name": "L'Académie",
         "addr": "2100 Rue Crescent, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "International restaurant",
         "amenity": "restaurant"
       },
@@ -286,7 +286,7 @@
       "properties": {
         "name": "Restaurant Santa Lucia",
         "addr": "1264 Rue Stanley, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Italian restaurant",
         "amenity": "restaurant"
       },
@@ -300,7 +300,7 @@
       "properties": {
         "name": "Station Guy-Concordia (Guy / De Maisonneuve)",
         "addr": "1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -314,7 +314,7 @@
       "properties": {
         "name": "Côte-des-Neiges / Summerhill",
         "addr": "Montreal, QC H3H 1T9",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -328,7 +328,7 @@
       "properties": {
         "name": "Pho Nguyen",
         "addr": "1452 Rue Saint-Mathieu, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Vietnamese restaurant",
         "amenity": "restaurant"
       },
@@ -356,7 +356,7 @@
       "properties": {
         "name": "Sushi Crescent",
         "addr": "1437 Crescent St, Montreal, Quebec H3G 2B2",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -370,7 +370,7 @@
       "properties": {
         "name": "Devi",
         "addr": "1450 Crescent St, Montreal, Quebec H3G 1R1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Indian restaurant (http://devimontreal.com/)",
         "amenity": "restaurant"
       },
@@ -384,7 +384,7 @@
       "properties": {
         "name": "Qinghua Dumplings (Express)",
         "addr": "1909 Rue Sainte-Catherine Ouest, Montréal, Québec, H3H 1M3",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Asian, Dumpling restaurant",
         "amenity": "restaurant"
       },
@@ -398,7 +398,7 @@
       "properties": {
         "name": "Restaurant Qinghua Dumpling",
         "addr": "1676 Avenue Lincoln, Montréal, Québec, H3H 1G9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Asian, Dumpling restaurant",
         "amenity": "restaurant"
       },
@@ -412,7 +412,7 @@
       "properties": {
         "name": "Burritoville",
         "addr": "2055 Rue Bishop, Montréal, QC, H3G 2E9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -454,7 +454,7 @@
       "properties": {
         "name": "Château Kabab",
         "addr": "2140 Guy St, Montreal, Quebec H3H 2N4",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Persian restaurant",
         "amenity": "restaurant"
       },
@@ -468,7 +468,7 @@
       "properties": {
         "name": "René-Lévesque / Bishop",
         "addr": "Montreal, QC H3G 2M5",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -482,7 +482,7 @@
       "properties": {
         "name": "Ferrari Restaurant - Café",
         "addr": "1407 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Italian restaurant (https://restoferrari.ca/)",
         "amenity": "restaurant"
       },
@@ -496,7 +496,7 @@
       "properties": {
         "name": "Man-na",
         "addr": "1421 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Korean restaurant",
         "amenity": "restaurant"
       },
@@ -510,7 +510,7 @@
       "properties": {
         "name": "Pizza Hut",
         "addr": "1431 Rue bishop, Montréal, Québec, H3G 2E4",
-        "opening_hours": "Mo-Th 10:30-23:00, Fr-Su 10:30-24:00",
+        "opening_hours": "Mo-Su 10:30-24:00",
         "description": "Pizza restaurant (https://www.pizzahut.ca/huts/ca-1/R34601/)",
         "amenity": "restaurant"
       },
@@ -524,7 +524,7 @@
       "properties": {
         "name": "Messa 14",
         "addr": "1425 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Mexican restaurant (http://www.mesa14.com/)",
         "amenity": "restaurant"
       },
@@ -538,7 +538,7 @@
       "properties": {
         "name": "Maison Chaïshaï",
         "addr": "2005 Rue Bishop, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Indian restaurant (http://www.ordercharcos.com/)",
         "amenity": "restaurant"
       },
@@ -552,7 +552,7 @@
       "properties": {
         "name": "Maison Inja - Cuisine Perse",
         "addr": "1458 Sherbrooke St W, Montreal, Quebec H3G 2S8",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -566,7 +566,7 @@
       "properties": {
         "name": "Cocktail Hawaii",
         "addr": "1645 Maisonneuve Blvd W, Montreal, Quebec H3H 2N3",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -580,7 +580,7 @@
       "properties": {
         "name": "NosThés",
         "addr": "1609 Saint-Catherine St W, Montreal, Quebec H3H 1L8",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -594,7 +594,7 @@
       "properties": {
         "name": "Restaurant Traditions",
         "addr": "2330 Guy St, Montreal, Quebec H3H 1E1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Mediterranean restaurant",
         "amenity": "restaurant"
       },
@@ -608,7 +608,7 @@
       "properties": {
         "name": "Chez Chen",
         "addr": "1618 Avenue Lincoln, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Chinese restaurant",
         "amenity": "restaurant"
       },
@@ -622,7 +622,7 @@
       "properties": {
         "name": "Angela Pizzeria & Restaurant",
         "addr": "1662 Boulevard de Maisonneuve O, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Pizza restaurant",
         "amenity": "restaurant"
       },
@@ -636,7 +636,7 @@
       "properties": {
         "name": "Student Tasty Biryani",
         "addr": "1620 Avenue Lincoln, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -650,7 +650,7 @@
       "properties": {
         "name": "Comptoir du chef",
         "addr": "2153 Guy St, Montreal, Quebec H3H 2R9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -678,7 +678,7 @@
       "properties": {
         "name": "Ici Restaurant Coréen",
         "addr": "1413 Rue Saint-Marc, Montréal, QC, H3H 1M1",
-        "opening_hours": "Mo,We-Su 11:00-21:00; Tu 15:00-21:00",
+        "opening_hours": "Mo-Su 11:00-21:00",
         "description": "Korean restaurant",
         "amenity": "restaurant"
       },
@@ -692,7 +692,7 @@
       "properties": {
         "name": "La Belle et le Bœuf",
         "addr": "1620 Saint-Catherine St W, Montreal, Quebec H3A 1L9",
-        "opening_hours": "Su-We 18:00-22:00; Th-Sa 12:30-22:00+",
+        "opening_hours": "Mo-Su 12:30-24:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -706,7 +706,7 @@
       "properties": {
         "name": "Burger bar crescent",
         "addr": "1465 Rue Crescent, Montréal, Québec, H3G 2B2",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -734,7 +734,7 @@
       "properties": {
         "name": "Yama",
         "addr": "1415 Rue de la Montagne, Montréal, QC H3G 1Z3",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -748,7 +748,7 @@
       "properties": {
         "name": "COQCOR",
         "addr": "1237 Rue Guy, Montréal, Québec, H3H 2K5",
-        "opening_hours": "12:00-22:00",
+        "opening_hours": "Mo-Su 12:00-22:00",
         "description": "Korean_fried_chicken restaurant",
         "amenity": "restaurant"
       },
@@ -762,7 +762,7 @@
       "properties": {
         "name": "Chez la Mere Michel",
         "addr": "1209 Rue Guy, Montréal, Québec, H3H 2K5",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -776,7 +776,7 @@
       "properties": {
         "name": "Trattoria Trestevere",
         "addr": "1237 Crescent St, Montreal, Quebec H3G 2B1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Italian restaurant",
         "amenity": "restaurant"
       },
@@ -790,7 +790,7 @@
       "properties": {
         "name": "Pizza Chez Danny",
         "addr": "1237 Rue de la Montagne, Montréal, QC H3G 1P1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -804,7 +804,7 @@
       "properties": {
         "name": "Chez Hailar",
         "addr": "1612 Rue Sherbrooke Ouest, Montréal, Québec",
-        "opening_hours": "Su-Th 11:00-23:00; Fr-Sa 11:00-01:00",
+        "opening_hours": "Mo-Su 11:00-23:00",
         "description": "Restaurant (http://www.chezhailar.com)",
         "amenity": "restaurant"
       },
@@ -818,7 +818,7 @@
       "properties": {
         "name": "Sherbrooke / Bishop",
         "addr": "Montreal, QC H3G 1K4",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -832,7 +832,7 @@
       "properties": {
         "name": "Kinton Ramen",
         "addr": "1211 Bishop St, Montreal, Quebec H3G 2E2",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Ramen restaurant",
         "amenity": "restaurant"
       },
@@ -846,7 +846,7 @@
       "properties": {
         "name": "Chez Cora",
         "addr": "1240 Drummond St, Montreal, Quebec H3G 1V7",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Breakfast restaurant (https://www.chezcora.com/)",
         "amenity": "restaurant"
       },
@@ -860,7 +860,7 @@
       "properties": {
         "name": "Schlouppe Bistrot",
         "addr": "2159 Rue Mackay, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Japanese restaurant",
         "amenity": "restaurant"
       },
@@ -874,7 +874,7 @@
       "properties": {
         "name": "Chai Paratha",
         "addr": "2340 Rue Guy, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Pakistani restaurant",
         "amenity": "restaurant"
       },
@@ -888,7 +888,7 @@
       "properties": {
         "name": "K2 Sushi",
         "addr": "1468 Rue Crescent, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Sushi restaurant",
         "amenity": "restaurant"
       },
@@ -902,7 +902,7 @@
       "properties": {
         "name": "Otto Yakitori",
         "addr": "1441 Rue Saint-Mathieu, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -916,7 +916,7 @@
       "properties": {
         "name": "René-Lévesque / Guy",
         "addr": "Montreal, QC",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -930,7 +930,7 @@
       "properties": {
         "name": "Sherbrooke / Côte-des-Neiges",
         "addr": "Montreal, QC H3H 1T4",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -944,7 +944,7 @@
       "properties": {
         "name": "Sherbrooke / Saint-Mathieu",
         "addr": "Montreal, QC H3H 1E4",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -958,7 +958,7 @@
       "properties": {
         "name": "Station Guy-Concordia (Maisonneuve / St-Mathieu)",
         "addr": "Accès A, 1801 St Mathieu St, Montreal, Quebec H3H 1J9",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -972,7 +972,7 @@
       "properties": {
         "name": "Guy / Sainte-Catherine",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -986,7 +986,7 @@
       "properties": {
         "name": "De Maisonneuve / de la Montagne",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1000,7 +1000,7 @@
       "properties": {
         "name": "Sainte-Catherine / Saint-Mathieu",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1014,7 +1014,7 @@
       "properties": {
         "name": "René-Lévesque / Guy",
         "addr": "Montreal, QC H3G 1S8",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1028,7 +1028,7 @@
       "properties": {
         "name": "De Maisonneuve / Bishop",
         "addr": "De Maisonneuve / Bishop",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1042,7 +1042,7 @@
       "properties": {
         "name": "Station Guy-Concordia (De Maisonneuve/St-Mathieu)",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1056,7 +1056,7 @@
       "properties": {
         "name": "Guy / René-Lévesque",
         "addr": "Montreal, QC H3H 2K7",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1070,7 +1070,7 @@
       "properties": {
         "name": "Saint-Mathieu / Sherbrooke",
         "addr": "Montreal, QC H3H 1E3",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1084,7 +1084,7 @@
       "properties": {
         "name": "Sherbrooke / Saint-Marc",
         "addr": "Montreal, QC H3H 1E3",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1098,7 +1098,7 @@
       "properties": {
         "name": "du Docteur-Penfield / Redpath",
         "addr": "Montreal, QC H3G 1B8",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1112,7 +1112,7 @@
       "properties": {
         "name": "Sainte-Catherine / de la Montagne",
         "addr": "Montreal, QC H3G 1P6",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1126,7 +1126,7 @@
       "properties": {
         "name": "Poke Monster",
         "addr": "1225 Blvd. De Maisonneuve Ouest, Montreal, Quebec H3G 1M3",
-        "opening_hours": "Su-Th 10:00-15:00; Fr,Sa 10:00-17:00",
+        "opening_hours": "Mo-Su 110:00-17:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1140,7 +1140,7 @@
       "properties": {
         "name": "La Medusa",
         "addr": "1218 Drummond St, Montreal, Quebec H3G 1V7",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Italian, Pizza restaurant (https://www.lamedusa.ca/)",
         "amenity": "restaurant"
       },
@@ -1154,7 +1154,7 @@
       "properties": {
         "name": "Parma Café",
         "addr": "1202 Bishop St, Montreal, Quebec H3G 2E3",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 08:00-21:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1182,7 +1182,7 @@
       "properties": {
         "name": "KimGalbi",
         "addr": "2100 Rue Saint-Mathieu, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1196,7 +1196,7 @@
       "properties": {
         "name": "Guy-Concordia",
         "addr": "1445 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "Unknown",
+        "opening_hours": "Mo-Su 05:00-02:00",
         "description": "Metro station",
         "amenity": "subway_station"
       },
@@ -1210,7 +1210,7 @@
       "properties": {
         "name": "Cuisine AuntDai",
         "addr": "1448 Rue Saint-Mathieu, Montréal, Québec, H3H 2H9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Chinese restaurant (http://auntdai.com)",
         "amenity": "restaurant"
       },
@@ -1238,7 +1238,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1252,7 +1252,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station with 45 docks",
         "amenity": "bicycle_rental"
       },
@@ -1266,7 +1266,7 @@
       "properties": {
         "name": "OFish Bishop",
         "addr": "1429 A Rue Bishop, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1280,8 +1280,8 @@
       "properties": {
         "name": "Sana",
         "addr": "1175A Rue Crescent, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
-        "description": "Pakistani, Indian;bangladeshi restaurant",
+        "opening_hours": "Mo-Su 11:00-22:00",
+        "description": "Pakistani, Indian; bangladeshi restaurant",
         "amenity": "restaurant"
       },
       "geometry": {
@@ -1294,7 +1294,7 @@
       "properties": {
         "name": "Notre Endroit",
         "addr": "1437 Boulevard René-Lévesque Ouest, Montréal, Québec",
-        "opening_hours": "Mo-Fr 11:30-22:30; Sa,Su 00:00-22:30",
+        "opening_hours": "Mo-Su 11:00-23:00",
         "description": "Indian, South_indian restaurant",
         "amenity": "restaurant"
       },
@@ -1308,7 +1308,7 @@
       "properties": {
         "name": "Escondite",
         "addr": "1224 Rue Drummond, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Mexican restaurant",
         "amenity": "restaurant"
       },
@@ -1322,7 +1322,7 @@
       "properties": {
         "name": "Misoya",
         "addr": "2065A Rue Bishop, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Ramen restaurant",
         "amenity": "restaurant"
       },
@@ -1336,7 +1336,7 @@
       "properties": {
         "name": "Chef Istanbul",
         "addr": "1510 Blvd. De Maisonneuve Ouest, Montreal, Quebec H3G 1N1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Turkish restaurant",
         "amenity": "restaurant"
       },
@@ -1350,7 +1350,7 @@
       "properties": {
         "name": "Mon Ami",
         "addr": "1488 Rue Sainte-Catherine Ouest, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1364,7 +1364,7 @@
       "properties": {
         "name": "Crossbar",
         "addr": "1390 Boulevard René-Lévesque Ouest, Montréal, Québec",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1378,7 +1378,7 @@
       "properties": {
         "name": "Gyu-Kaku",
         "addr": "1255 Rue Crescent, Montréal, Québec, H3G 2B1",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Japanese, Barbecue restaurant (https://www.gyu-kaku.com/montreal/)",
         "amenity": "restaurant"
       },
@@ -1406,7 +1406,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1420,7 +1420,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1432,23 +1432,9 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Lo",
-        "addr": "Address unavailable",
-        "opening_hours": "Typically 11:00-22:00",
-        "description": "Restaurant",
-        "amenity": "restaurant"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-73.5733823, 45.4969261]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
         "name": "Bis Ristorante",
         "addr": "1229 Rue de la Montagne, Montréal, QC H3G 1Z2",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Italian restaurant",
         "amenity": "restaurant"
       },
@@ -1462,7 +1448,7 @@
       "properties": {
         "name": "Sushi Rosa",
         "addr": "1231 Drummond St, Montreal, Quebec H3G 1V8",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Sushi restaurant",
         "amenity": "restaurant"
       },
@@ -1476,7 +1462,7 @@
       "properties": {
         "name": "Poke Bento",
         "addr": "1452 St Mathieu St B, Montreal, Quebec H3H 2H9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1490,7 +1476,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "Unknown",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1504,7 +1490,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station with 19 docks",
         "amenity": "bicycle_rental"
       },
@@ -1518,7 +1504,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station with 31 docks",
         "amenity": "bicycle_rental"
       },
@@ -1530,23 +1516,9 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Kinka Izakaya",
-        "addr": "4006 Saint-Catherine St W, Montreal, Quebec H3Z 1P2",
-        "opening_hours": "\"en construction\"",
-        "description": "Japanese restaurant",
-        "amenity": "restaurant"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-73.5786514, 45.4941098]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
         "name": "I am Pho",
         "addr": "1444 St Mathieu St, Montreal, Quebec H3H 2H9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Vietnamese restaurant",
         "amenity": "restaurant"
       },
@@ -1560,7 +1532,7 @@
       "properties": {
         "name": "DonDonYa",
         "addr": "1433A Bishop St, Montreal, Quebec H3G 2E4",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1574,7 +1546,7 @@
       "properties": {
         "name": "Chatpata",
         "addr": "1620 Av. Lincoln, Montréal, QC H3H 1G9",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Chinese, Indian restaurant",
         "amenity": "restaurant"
       },
@@ -1588,7 +1560,7 @@
       "properties": {
         "name": "La Hueca by Masa",
         "addr": "Le Faubourg Sainte Catherine, 1616 Saint-Catherine St W, Montreal, Quebec H3H 1L7",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1602,7 +1574,7 @@
       "properties": {
         "name": "Patty Slaps",
         "addr": "1449 Saint-Catherine St W, Montreal, Quebec H3G 1S6",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1616,7 +1588,7 @@
       "properties": {
         "name": "Chimaek Gana",
         "addr": "2080 St Mathieu St, Montreal, Quebec H3H 2J4",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Chicken restaurant",
         "amenity": "restaurant"
       },
@@ -1630,7 +1602,7 @@
       "properties": {
         "name": "Hazukido",
         "addr": "1629 Saint-Catherine St W, Montreal, Quebec H3H 1L8",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 09:00-19:00",
         "description": "Dessert, Bubble_tea restaurant",
         "amenity": "restaurant"
       },
@@ -1644,7 +1616,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1658,7 +1630,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1672,7 +1644,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station",
         "amenity": "bicycle_rental"
       },
@@ -1686,7 +1658,7 @@
       "properties": {
         "name": "Bixi",
         "addr": "Address unavailable",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bike sharing station with 19 docks",
         "amenity": "bicycle_rental"
       },
@@ -1700,7 +1672,7 @@
       "properties": {
         "name": "Garage Beirut",
         "addr": "1238 Rue Mackay, Montréal, QC, H3G 2H4",
-        "opening_hours": "Typically 11:00-22:00",
+        "opening_hours": "Mo-Su 11:00-22:00",
         "description": "Restaurant",
         "amenity": "restaurant"
       },
@@ -1728,7 +1700,7 @@
       "properties": {
         "name": "sparta chicken",
         "addr": "1235 Rue Guy, Montréal, Québec, H3H 2K5",
-        "opening_hours": "13:00-3:00",
+        "opening_hours": "Mo-Su 13:00-03:00",
         "description": "Greek_fried_chiken restaurant",
         "amenity": "restaurant"
       },
@@ -1742,7 +1714,7 @@
       "properties": {
         "name": "Cafe Myriade",
         "addr": "1432 Mackay St, Montreal, Quebec H3G 2H7",
-        "opening_hours": "8am-7pm",
+        "opening_hours": "Mo-Su 08:00-19:00",
         "description": "Fresh-roasted coffees brewed in a contemporary space, plus baked goods & croissants.",
         "amenity": "restaurant"
       },
@@ -1756,7 +1728,7 @@
       "properties": {
         "name": "McKibbin's",
         "addr": "1426 Bishop St, Montreal, Quebec H3G 2E6",
-        "opening_hours": "11:30 a.m.–3 a.m.",
+        "opening_hours": "Mo-Su 11:30–03:00",
         "description": "Cozy, woodsy pub (part of a local chain) for Celtic comfort food, live music, pitchers & TV sports.",
         "amenity": "restaurant"
       },
@@ -1770,7 +1742,7 @@
       "properties": {
         "name": "Starbucks",
         "addr": "1457 Saint-Catherine St W, Montreal, Quebec H3G 1S6",
-        "opening_hours": "6:30 a.m.–10 p.m.",
+        "opening_hours": "Mo-Su 06:30-22:00",
         "description": "Seattle-based coffeehouse chain known for its signature roasts, light bites and WiFi availability.",
         "amenity": "restaurant"
       },
@@ -1784,7 +1756,7 @@
       "properties": {
         "name": "Starbucks",
         "addr": "2000 Guy St, Montreal, Quebec H3H 2N4",
-        "opening_hours": "6:30 a.m.–10 p.m.",
+        "opening_hours": "Mo-Su 06:30-22:00",
         "description": "Seattle-based coffeehouse chain known for its signature roasts, light bites and WiFi availability.",
         "amenity": "restaurant"
       },
@@ -1798,7 +1770,7 @@
       "properties": {
         "name": "Java U Guy",
         "addr": "1455 Guy St, Montreal, Quebec H3H 2L5",
-        "opening_hours": "7 a.m.–9 p.m.",
+        "opening_hours": "Mo-Su 07:00-21:00",
         "description": "Cafe",
         "amenity": "restaurant"
       },
@@ -1812,7 +1784,7 @@
       "properties": {
         "name": "A&W",
         "addr": "1550 Blvd. De Maisonneuve Ouest #101, Montreal, Quebec H3G 1N1",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Fast-food outlet serving up namesake root beer, plus burgers, chicken & fries.",
         "amenity": "restaurant"
       },
@@ -1826,7 +1798,7 @@
       "properties": {
         "name": "Matcha Zanmai",
         "addr": "1428 Mackay St, Montreal, Quebec H3G 2H9",
-        "opening_hours": "12-10pm",
+        "opening_hours": "Mo-Su 12:00-22:00",
         "description": "Japanese sweets restaurant",
         "amenity": "restaurant"
       },
@@ -1840,7 +1812,7 @@
       "properties": {
         "name": "Ganadara",
         "addr": "1417 Mackay St, Montreal, Quebec H3G 0H2",
-        "opening_hours": "11:30 a.m.–8:30 p.m.",
+        "opening_hours": "Mo-Su 11:30-20:30",
         "description": "Hearty Korean favourites, from seafood pancakes to bibimbop, dished up in a bustling, compact venue.",
         "amenity": "restaurant"
       },
@@ -1854,7 +1826,7 @@
       "properties": {
         "name": "Vanier Library",
         "addr": "7141 Sherbrooke St W, Montreal, Quebec H4B 1R6",
-        "opening_hours": "24 Hours",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Loyola Campus University Library",
         "amenity": "library"
       },
@@ -1868,7 +1840,7 @@
       "properties": {
         "name": "Hive Co-op Cafe",
         "addr": "7141 Sherbrooke Street W. CJ, 2 341 2nd floor, Montreal, Quebec H4B 1R6",
-        "opening_hours": "8:15am-4:00p.m.",
+        "opening_hours": "Mo-Fr 08:30-15:30",
         "description": "Campus Cafe",
         "amenity": "restaurant"
       },
@@ -1880,23 +1852,9 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Second Cup Cafe",
-        "addr": "7335-7345 Sherbrooke St W, Montreal, Quebec H4B 1R9",
-        "opening_hours": "7:00am-9:00p.m.",
-        "description": "Coffee Shop",
-        "amenity": "restaurant"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-73.63996001226405, 45.456220187189544]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
         "name": "Subway",
         "addr": "7420 Sherbrooke St W, Montreal, Quebec H4B 1R7",
-        "opening_hours": "7:00am-10:00p.m.",
+        "opening_hours": "Mo-Su 07:00-22:00",
         "description": "Casual counter-serve chain for build-your-own sandwiches & salads, with health-conscious options.",
         "amenity": "restaurant"
       },
@@ -1910,7 +1868,7 @@
       "properties": {
         "name": "Université Concordia / Campus Loyola",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1924,7 +1882,7 @@
       "properties": {
         "name": "Université Concordia / Campus Loyola",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1938,7 +1896,7 @@
       "properties": {
         "name": "Sherbrooke / West Broadway",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1952,7 +1910,7 @@
       "properties": {
         "name": "West Broadway / Sherbrooke",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1966,7 +1924,7 @@
       "properties": {
         "name": "West Broadway / De Terrebonne",
         "addr": "Montreal, QC H4B 1R6",
-        "opening_hours": "24/7",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Bus stop",
         "amenity": "bus_station"
       },
@@ -1980,7 +1938,7 @@
       "properties": {
         "name": "Souvlaki George® Restaurant",
         "addr": "6995 Monkland Ave, Montreal, Quebec H4B 1J8",
-        "opening_hours": "11:00am-9:00p.m.",
+        "opening_hours": "Mo-Su 11:00-21:00",
         "description": "Quick-serve grilled kebab platters, gyro pita combos & North American eats in an informal space.",
         "amenity": "restaurant"
       },
@@ -1994,7 +1952,7 @@
       "properties": {
         "name": "Dagwoods La Sandwicherie",
         "addr": "6969 Sherbrooke St W, Montreal, Quebec H4B 1R1",
-        "opening_hours": "11:00am-9:00p.m.",
+        "opening_hours": "Mo-Su 11:00-21:00",
         "description": "Sandwhich Shop.",
         "amenity": "restaurant"
       },
@@ -2008,7 +1966,7 @@
       "properties": {
         "name": "Recreational park / Parc de loisirs -Concordia University - Loyola Campus",
         "addr": "Montreal, Quebec H4B 1E1",
-        "opening_hours": "Dawn to dusk",
+        "opening_hours": "Mo-Su 00:00-24:00",
         "description": "Public park, Dogs Allowed",
         "amenity": "park"
       },
@@ -2022,7 +1980,7 @@
       "properties": {
         "name": "Concordia Stadium",
         "addr": "7200 Sherbrooke St W, Montreal, Quebec H4B 2A4",
-        "opening_hours": "9am-5pm",
+        "opening_hours": "Mo-Fr 09:00-17:00",
         "description": "Concordia Stingers Stadium",
         "amenity": "location"
       },
@@ -2036,7 +1994,7 @@
       "properties": {
         "name": "Stinger Dome",
         "addr": "7200 Sherbrooke St W, Montreal, Quebec H4B 1R3",
-        "opening_hours": "9am-10pm",
+        "opening_hours": "Mo-Fr 09:00-22:00",
         "description": "Concordia Stingers Dome",
         "amenity": "location"
       },

--- a/client/components/LocationInfo.tsx
+++ b/client/components/LocationInfo.tsx
@@ -3,6 +3,7 @@ import { Ionicons } from '@expo/vector-icons';
 import React from 'react';
 import { Text, StyleSheet, View, TouchableOpacity } from 'react-native';
 import { IconSymbol } from './ui/IconSymbol';
+import { isCurrentlyOpen } from '@/services/PointsOfInterestService';
 
 const iconMap: Record<string, keyof typeof Ionicons.glyphMap> = {
   bicycle_rental: 'bicycle-outline',
@@ -24,6 +25,8 @@ export function LocationInfo() {
 
   const isCustomPOI = endLocation?.data?.hours !== undefined;
   const iconName = iconMap[endLocation?.data?.type] || 'location';
+
+  const locationIsOpen = isCustomPOI ? isCurrentlyOpen(endLocation?.data?.hours) : false;
 
   return (
     <View style={styles.container}>
@@ -47,8 +50,8 @@ export function LocationInfo() {
       </View>
 
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-        <Text style={[styles.isOpen, { color: endLocation?.data?.isOpen ? 'green' : 'red' }]}>
-          {endLocation?.data?.isOpen ? 'Open Now' : 'Closed Now'}
+        <Text style={[styles.isOpen, { color: locationIsOpen ? 'green' : 'red' }]}>
+          {locationIsOpen ? 'Open Now' : 'Closed Now'}
         </Text>
 
         {isCustomPOI && endLocation?.data?.hours && (

--- a/client/services/PointsOfInterestService.ts
+++ b/client/services/PointsOfInterestService.ts
@@ -76,6 +76,8 @@ const isCurrentTimeInRange = (currentTime: number, timeRange: string): boolean =
 };
 
 const isCurrentlyOpen = (openingHours?: string): boolean => {
+  if (openingHours === '24/7') return true;
+
   if (!openingHours) return false;
 
   const now = new Date();
@@ -148,12 +150,6 @@ class PointsOfInterestService {
 
     if (closestFeature === null) return null;
     return extractLocation(closestFeature);
-  }
-
-  getPOIByName(name: string): Location | null {
-    const poi = this.featureCollection.features.find((f) => f.properties?.name === name);
-    if (!poi) return null;
-    return extractLocation(poi);
   }
 }
 

--- a/client/services/PointsOfInterestService.ts
+++ b/client/services/PointsOfInterestService.ts
@@ -75,7 +75,7 @@ const isCurrentTimeInRange = (currentTime: number, timeRange: string): boolean =
   return currentTime >= startTimeMinutes && currentTime < endTimeMinutes;
 };
 
-export function isCurrentlyOpen(openingHours?: string): boolean {
+function isCurrentlyOpen(openingHours?: string): boolean {
   if (openingHours === '24/7') return true;
 
   if (!openingHours) return false;
@@ -160,4 +160,5 @@ for (const poi of pointsOfInterestService.getFeatureCollection().features) {
   });
 }
 
+export { isCurrentlyOpen };
 export default pointsOfInterestService;

--- a/client/services/PointsOfInterestService.ts
+++ b/client/services/PointsOfInterestService.ts
@@ -4,25 +4,101 @@ import poiFeatureCollection from '@/assets/geojson/pois.json';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import LocalLocations from './LocalLocations';
 
+const isCurrentlyOpen = (openingHours?: string): boolean => {
+  if (!openingHours) return false;
+  const now = new Date();
+  const currentDay = now.getDay();
+  const currentHour = now.getHours();
+  const currentMinute = now.getMinutes();
+  const currentTime = currentHour * 60 + currentMinute;
+
+  const dayMap: Record<number, string> = {
+    0: 'Su',
+    1: 'Mo',
+    2: 'Tu',
+    3: 'We',
+    4: 'Th',
+    5: 'Fr',
+    6: 'Sa',
+  };
+  const currentDayCode = dayMap[currentDay];
+
+  const ruleSets = openingHours.split(';').map((set) => set.trim());
+
+  for (const ruleSet of ruleSets) {
+    if (!ruleSet) continue;
+
+    const parts = ruleSet.split(' ');
+    if (parts.length < 2) continue;
+
+    const dayRange = parts[0];
+    const timeRange = parts[1];
+    const dayRanges = dayRange.split(',');
+
+    let isDayIncluded = false;
+
+    for (const range of dayRanges) {
+      if (range.includes('-')) {
+        const [startDay, endDay] = range.split('-');
+        const days = Object.values(dayMap);
+        const startDayIndex = days.indexOf(startDay);
+        const endDayIndex = days.indexOf(endDay);
+        const currentDayIndex = days.indexOf(currentDayCode);
+
+        if (startDayIndex !== -1 && endDayIndex !== -1 && currentDayIndex !== -1) {
+          if (startDayIndex <= endDayIndex) {
+            isDayIncluded = currentDayIndex >= startDayIndex && currentDayIndex <= endDayIndex;
+          } else {
+            isDayIncluded = currentDayIndex >= startDayIndex || currentDayIndex <= endDayIndex;
+          }
+
+          if (isDayIncluded) break;
+        }
+      } else if (range === currentDayCode) {
+        isDayIncluded = true;
+        break;
+      }
+    }
+
+    if (!isDayIncluded) continue;
+    if (timeRange) {
+      const [startTime, endTime] = timeRange.split('-');
+
+      const startParts = startTime.split(':').map(Number);
+      const endParts = endTime.split(':').map(Number);
+      const startTimeMinutes = startParts[0] * 60 + (startParts[1] || 0);
+
+      let endTimeMinutes = endParts[0] * 60 + (endParts[1] || 0);
+      if (endParts[0] === 24) {
+        endTimeMinutes = 24 * 60;
+      }
+      if (endTimeMinutes <= startTimeMinutes) {
+        endTimeMinutes += 24 * 60;
+      }
+      return currentTime >= startTimeMinutes && currentTime < endTimeMinutes;
+    }
+  }
+  return false;
+};
+
 const extractLocation = (feature: Feature<Point>): Location => {
   return {
     name: feature.properties?.name,
     coordinates: feature.geometry.coordinates,
     data: {
       address: feature.properties?.addr,
-      // Currently, we assume all POIs are open
-      isOpen: true,
+      isOpen: isCurrentlyOpen(feature.properties?.opening_hours),
       hours: feature.properties?.opening_hours,
       category: feature.properties?.description,
       type: feature.properties?.amenity,
     },
   };
 };
+
 class PointsOfInterestService {
   private readonly featureCollection: FeatureCollection<Point>;
 
   constructor() {
-    // We only support POIs that are Points
     this.featureCollection = poiFeatureCollection as FeatureCollection<Point>;
   }
 
@@ -46,11 +122,16 @@ class PointsOfInterestService {
     if (closestFeature === null) return null;
     return extractLocation(closestFeature);
   }
+
+  getPOIByName(name: string): Location | null {
+    const poi = this.featureCollection.features.find((f) => f.properties?.name === name);
+
+    if (!poi) return null;
+    return extractLocation(poi as Feature<Point>);
+  }
 }
 
 const pointsOfInterestService = new PointsOfInterestService();
-
-// Add outdoor POIs to location input autocomplete
 for (const poi of pointsOfInterestService.getFeatureCollection().features) {
   if (!poi.properties?.name) continue;
   LocalLocations.getInstance().add(poi.properties.name, (_: string) => {

--- a/client/services/PointsOfInterestService.ts
+++ b/client/services/PointsOfInterestService.ts
@@ -14,29 +14,42 @@ const dayMap: Record<number, string> = {
   6: 'Sa',
 };
 
+const isInDayRange = (
+  currentDayIndex: number,
+  startDayIndex: number,
+  endDayIndex: number
+): boolean => {
+  if (startDayIndex <= endDayIndex) {
+    return currentDayIndex >= startDayIndex && currentDayIndex <= endDayIndex;
+  }
+  return currentDayIndex >= startDayIndex || currentDayIndex <= endDayIndex;
+};
+
 const isCurrentDayInRange = (currentDayCode: string, dayRange: string): boolean => {
   const dayRanges = dayRange.split(',');
+  const days = Object.values(dayMap);
+  const currentDayIndex = days.indexOf(currentDayCode);
+
+  if (currentDayIndex === -1) {
+    return false;
+  }
 
   for (const range of dayRanges) {
-    if (range.includes('-')) {
-      const [startDay, endDay] = range.split('-');
-      const days = Object.values(dayMap);
-      const startDayIndex = days.indexOf(startDay);
-      const endDayIndex = days.indexOf(endDay);
-      const currentDayIndex = days.indexOf(currentDayCode);
-
-      if (startDayIndex !== -1 && endDayIndex !== -1 && currentDayIndex !== -1) {
-        if (startDayIndex <= endDayIndex) {
-          if (currentDayIndex >= startDayIndex && currentDayIndex <= endDayIndex) {
-            return true;
-          }
-        } else {
-          if (currentDayIndex >= startDayIndex || currentDayIndex <= endDayIndex) {
-            return true;
-          }
-        }
+    if (!range.includes('-')) {
+      if (range === currentDayCode) {
+        return true;
       }
-    } else if (range === currentDayCode) {
+      continue;
+    }
+    const [startDay, endDay] = range.split('-');
+    const startDayIndex = days.indexOf(startDay);
+    const endDayIndex = days.indexOf(endDay);
+
+    if (startDayIndex === -1 || endDayIndex === -1) {
+      continue;
+    }
+
+    if (isInDayRange(currentDayIndex, startDayIndex, endDayIndex)) {
       return true;
     }
   }

--- a/client/services/PointsOfInterestService.ts
+++ b/client/services/PointsOfInterestService.ts
@@ -75,7 +75,7 @@ const isCurrentTimeInRange = (currentTime: number, timeRange: string): boolean =
   return currentTime >= startTimeMinutes && currentTime < endTimeMinutes;
 };
 
-const isCurrentlyOpen = (openingHours?: string): boolean => {
+export function isCurrentlyOpen(openingHours?: string): boolean {
   if (openingHours === '24/7') return true;
 
   if (!openingHours) return false;
@@ -108,7 +108,7 @@ const isCurrentlyOpen = (openingHours?: string): boolean => {
   }
 
   return false;
-};
+}
 
 const extractLocation = (feature: Feature<Point>): Location => {
   return {
@@ -116,7 +116,6 @@ const extractLocation = (feature: Feature<Point>): Location => {
     coordinates: feature.geometry.coordinates,
     data: {
       address: feature.properties?.addr,
-      isOpen: isCurrentlyOpen(feature.properties?.opening_hours),
       hours: feature.properties?.opening_hours,
       category: feature.properties?.description,
       type: feature.properties?.amenity,


### PR DESCRIPTION
Previously, the `isOpen` was always set to true regardless of the actual opening hours of a POI.

The updated `PointsOfInterestService.ts` properly compares the current day and time with the opening hours to determine if a location is currently open or closed.

The format of the opening hours data in the `pois.json` file were updated to follow the expected format in `PointsOfInterestService.ts`. For example: Mo-Fr 09:00-22:00